### PR TITLE
MET-872: Add delete document API to restlastic search client

### DIFF
--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -126,6 +126,10 @@ class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[
     runEsCommand(EmptyObject, s"/${index.name}", DELETE)
   }
 
+  def deleteDocument(index: Index, tpe: Type, query: QueryRoot): Future[RawJsonResponse] = {
+    runEsCommand(query, s"/${index.name}/${tpe.name}/_query", DELETE)
+  }
+
   def startScrollRequest(index: Index, tpe: Type, query: QueryRoot, resultWindow: String = "1m"): Future[ScrollId] = {
     val uriQuery = UriQuery("scroll" -> resultWindow, "search_type" -> "scan")
     runEsCommand(query, s"/${index.name}/${tpe.name}/_search", query = uriQuery).map { resp =>

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -146,6 +146,25 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
         res.jsonStr should include(IndexName)
       }
     }
+
+    "Support delete documents" in {
+      val ir = restClient.index(index, tpe, Document("doc7", Map("text7" -> "here7")))
+      whenReady(ir) { ir =>
+        ir.created should be(true)
+      }
+      refresh()
+      val resFut = restClient.query(index, tpe, QueryRoot(TermQuery("text7", "here7")))
+      whenReady(resFut) { res =>
+        res.sourceAsMap.toList should be(List(Map("text7" -> "here7")))
+      }
+      val delFut = restClient.deleteDocument(index, tpe, QueryRoot(TermQuery("text7", "here7")))
+      val res = Await.result(delFut, 10.seconds)
+      print(s"res: $res")
+      val resFut1 = restClient.query(index, tpe, QueryRoot(TermQuery("text7", "here7")))
+      whenReady(resFut1) { res =>
+        res.sourceAsMap.toList should be(List())
+      }
+    }
   }
 }
 


### PR DESCRIPTION
Added delete document by query api
- Added unit test
- Run unit test 
