### PR TITLE
Incorporate Russell's feedbacks and fix version (1.0.3 -> 1.0.3-SNAPS…

### DIFF
--- a/elasticsearch-akka/pom.xml
+++ b/elasticsearch-akka/pom.xml
@@ -4,12 +4,12 @@
   <artifactId>elasticsearch-akka</artifactId>
   <name>elasticsearch-akka</name>
   <packaging>jar</packaging>
-  <version>1.0.3</version>
+  <version>1.0.3-SNAPSHOT</version>
 
   <parent>
     <artifactId>all</artifactId>
     <groupId>com.sumologic.elasticsearch</groupId>
-    <version>1.0.3</version>
+    <version>1.0.3-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>com.sumologic.elasticsearch</groupId>
       <artifactId>elasticsearch-core</artifactId>
-      <version>1.0.3</version>
+      <version>1.0.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/elasticsearch-aws/pom.xml
+++ b/elasticsearch-aws/pom.xml
@@ -4,14 +4,14 @@
   <artifactId>elasticsearch-aws</artifactId>
   <name>elasticsearch-aws</name>
   <packaging>jar</packaging>
-  <version>1.0.3</version>
+  <version>1.0.3-SNAPSHOT</version>
   <scm><connection>scm:git:git@github.com:Sanyaku/sumologic.git/tags/all-1.0.3/sumologic.git</connection></scm>
 
 
   <parent>
     <artifactId>all</artifactId>
     <groupId>com.sumologic.elasticsearch</groupId>
-    <version>1.0.3</version>
+    <version>1.0.3-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>com.sumologic.elasticsearch</groupId>
       <artifactId>elasticsearch-core</artifactId>
-      <version>1.0.3</version>
+      <version>1.0.3-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/elasticsearch-core/pom.xml
+++ b/elasticsearch-core/pom.xml
@@ -3,12 +3,12 @@
   <artifactId>elasticsearch-core</artifactId>
   <name>elasticsearch-core</name>
   <packaging>jar</packaging>
-  <version>1.0.3</version>
+  <version>1.0.3-SNAPSHOT</version>
 
   <parent>
     <artifactId>all</artifactId>
     <groupId>com.sumologic.elasticsearch</groupId>
-    <version>1.0.3</version>
+    <version>1.0.3-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.sumologic.elasticsearch</groupId>
       <artifactId>elasticsearch-test</artifactId>
-      <version>1.0.3</version>
+      <version>1.0.3-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
 

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -158,8 +158,7 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
         res.sourceAsMap.toList should be(List(Map("text7" -> "here7")))
       }
       val delFut = restClient.deleteDocument(index, tpe, QueryRoot(TermQuery("text7", "here7")))
-      val res = Await.result(delFut, 10.seconds)
-      print(s"res: $res")
+      whenReady(delFut)
       val resFut1 = restClient.query(index, tpe, QueryRoot(TermQuery("text7", "here7")))
       whenReady(resFut1) { res =>
         res.sourceAsMap.toList should be(List())

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -158,7 +158,7 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
         res.sourceAsMap.toList should be(List(Map("text7" -> "here7")))
       }
       val delFut = restClient.deleteDocument(index, tpe, QueryRoot(TermQuery("text7", "here7")))
-      whenReady(delFut)
+      Await.result(delFut, 10.seconds)
       val resFut1 = restClient.query(index, tpe, QueryRoot(TermQuery("text7", "here7")))
       whenReady(resFut1) { res =>
         res.sourceAsMap.toList should be(List())

--- a/elasticsearch-test/pom.xml
+++ b/elasticsearch-test/pom.xml
@@ -4,7 +4,7 @@
   <artifactId>elasticsearch-test</artifactId>
   <name>elasticsearch-test</name>
   <packaging>jar</packaging>
-  <version>1.0.3</version>
+  <version>1.0.3-SNAPSHOT</version>
   <scm><connection>scm:git:git@github.com:Sanyaku/sumologic.git/tags/all-1.0.3/sumologic.git</connection></scm>
 
   <properties>
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>all</artifactId>
     <groupId>com.sumologic.elasticsearch</groupId>
-    <version>1.0.3</version>
+    <version>1.0.3-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.sumologic.elasticsearch</groupId>
     <artifactId>all</artifactId>
     <name>all</name>
-    <version>1.0.3</version>
+    <version>1.0.3-SNAPSHOT</version>
     <packaging>pom</packaging>
     <licenses>
         <license>


### PR DESCRIPTION
- Fixed version from "1.0.3" to "1.0.3-SNAPSHOT"

Will update the test to WhenReady after updating to return type of deleteIndex and deleteDocument. Currently they are RawJsonResponse and cannot be easily combined with WhenReady. 
