### PR TITLE
Add TimeStampMapping to MappingDsl

### DIFF
--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/MappingDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/MappingDsl.scala
@@ -94,6 +94,12 @@ trait MappingDsl extends DslCommons {
     }
   }
 
+  case class TimeStampMapping(enabled: Boolean) extends FieldMapping {
+    val _timestamp = "_timestamp"
+    val _enabled = "enabled"
+    override def toJson: Map[String, Any] = Map(_timestamp -> Map(_enabled -> enabled))
+  }
+
   case class CompletionContext(path: String)
 }
 

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/MappingDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/MappingDsl.scala
@@ -55,13 +55,14 @@ trait MappingDsl extends DslCommons {
     override def toJson: Map[String, Any] = Map(tpe.name -> mapping.toJson)
   }
 
-  case class IndexMapping(fields: Map[String, FieldMapping]) extends EsOperation {
-    override def toJson: Map[String, Any] = Map(_properties -> fields.mapValues(_.toJson))
+  case class IndexMapping(fields: Map[String, FieldMapping], enabled:EnabledFiledMapping) extends EsOperation {
+    override def toJson: Map[String, Any] = Map(_properties -> fields.mapValues(_.toJson), _timestamp -> enabled.toJson)
   }
 
   sealed trait FieldMapping extends EsOperation
 
   val _properties = "properties"
+  val _timestamp = "_timestamp"
   val _type = "type"
   val _index = "index"
 
@@ -94,10 +95,9 @@ trait MappingDsl extends DslCommons {
     }
   }
 
-  case class TimeStampMapping(enabled: Boolean) extends FieldMapping {
-    val _timestamp = "_timestamp"
+  case class EnabledFiledMapping(enabled: Boolean) extends FieldMapping {
     val _enabled = "enabled"
-    override def toJson: Map[String, Any] = Map(_timestamp -> Map(_enabled -> enabled))
+    override def toJson: Map[String, Any] = Map(_enabled -> enabled)
   }
 
   case class CompletionContext(path: String)


### PR DESCRIPTION
Added TimeStampMapping to Mapping Dsl

TimeStampMapping is of the following format

```
      "_timestamp": { 
        "enabled": true
      }
```

https://www.elastic.co/guide/en/elasticsearch/reference/current/mapping-timestamp-field.html
