### PR TITLE
limit aws dependencies to aws-java-sdk-core

### DIFF
--- a/elasticsearch-aws/pom.xml
+++ b/elasticsearch-aws/pom.xml
@@ -36,7 +36,7 @@
 
     <dependency>
       <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk</artifactId>
+      <artifactId>aws-java-sdk-core</artifactId>
       <version>1.10.62</version>
     </dependency>
 


### PR DESCRIPTION
Hi!  Thanks for a great library!

I am using this in aws lambda, and the code deploy size makes a big difference there.

We only need aws-java-sdk-core for the signing utilities, so we can drop the rest of the aws package.

thanks!
