### PR TITLE
Added Range query to QueryDsl.

### DIFF
--- a/elasticsearch-akka/pom.xml
+++ b/elasticsearch-akka/pom.xml
@@ -4,12 +4,12 @@
   <artifactId>elasticsearch-akka</artifactId>
   <name>elasticsearch-akka</name>
   <packaging>jar</packaging>
-  <version>1.0.9-SNAPSHOT</version>
+  <version>1.0.11-SNAPSHOT</version>
 
   <parent>
     <artifactId>all</artifactId>
     <groupId>com.sumologic.elasticsearch</groupId>
-    <version>1.0.9-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 
@@ -22,7 +22,7 @@
     <dependency>
       <groupId>com.sumologic.elasticsearch</groupId>
       <artifactId>elasticsearch-core</artifactId>
-      <version>1.0.9-SNAPSHOT</version>
+      <version>1.0.11-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/elasticsearch-aws/pom.xml
+++ b/elasticsearch-aws/pom.xml
@@ -4,13 +4,13 @@
   <artifactId>elasticsearch-aws</artifactId>
   <name>elasticsearch-aws</name>
   <packaging>jar</packaging>
-  <version>1.0.9-SNAPSHOT</version>
+  <version>1.0.11-SNAPSHOT</version>
   <scm><connection>scm:git:git@github.com:Sanyaku/sumologic.git/tags/all-1.0.4/sumologic.git</connection></scm>
 
   <parent>
     <artifactId>all</artifactId>
     <groupId>com.sumologic.elasticsearch</groupId>
-    <version>1.0.9-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 
@@ -24,7 +24,7 @@
     <dependency>
       <groupId>com.sumologic.elasticsearch</groupId>
       <artifactId>elasticsearch-core</artifactId>
-      <version>1.0.9-SNAPSHOT</version>
+      <version>1.0.11-SNAPSHOT</version>
     </dependency>
 
     <dependency>

--- a/elasticsearch-core/pom.xml
+++ b/elasticsearch-core/pom.xml
@@ -3,12 +3,12 @@
   <artifactId>elasticsearch-core</artifactId>
   <name>elasticsearch-core</name>
   <packaging>jar</packaging>
-  <version>1.0.9-SNAPSHOT</version>
+  <version>1.0.11-SNAPSHOT</version>
 
   <parent>
     <artifactId>all</artifactId>
     <groupId>com.sumologic.elasticsearch</groupId>
-    <version>1.0.9-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 
@@ -26,7 +26,7 @@
     <dependency>
       <groupId>com.sumologic.elasticsearch</groupId>
       <artifactId>elasticsearch-test</artifactId>
-      <version>1.0.9-SNAPSHOT</version>
+      <version>1.0.11-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
 

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
@@ -87,6 +87,39 @@ trait QueryDsl extends DslCommons {
     }
   }
 
+  case class Range(key: String, bounds: RangeBound*) extends Query {
+    val _range = "range"
+    val boundsMap = Map(key -> (bounds :\ Map[String, Any]())(_.toJson ++ _))
+
+    override def toJson: Map[String, Any] =  Map(_range -> boundsMap)
+  }
+
+  sealed trait RangeBound extends EsOperation
+
+  case class Gt(value: String) extends RangeBound {
+    val _gt = "gt"
+
+    override def toJson: Map[String, Any] = Map(_gt -> value)
+  }
+
+  case class Gte(value: String) extends RangeBound {
+    val _gte = "gte"
+
+    override def toJson: Map[String, Any] = Map(_gte -> value)
+  }
+
+  case class Lt(value: String) extends RangeBound {
+    val _lt = "lt"
+
+    override def toJson: Map[String, Any] = Map(_lt -> value)
+  }
+
+  case class Lte(value: String) extends RangeBound {
+    val _lte = "lte"
+
+    override def toJson: Map[String, Any] = Map(_lte -> value)
+  }
+
   case class WildcardQuery(key: String, value: String) extends Query {
     val _wildcard = "wildcard"
 

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
@@ -87,7 +87,7 @@ trait QueryDsl extends DslCommons {
     }
   }
 
-  case class Range(key: String, bounds: RangeBound*) extends Query {
+  case class RangeQuery(key: String, bounds: RangeBound*) extends Query {
     val _range = "range"
     val boundsMap = Map(key -> (bounds :\ Map[String, Any]())(_.toJson ++ _))
 

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -219,6 +219,49 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       }
 
     }
+
+    "Support range queries" in {
+      val rangeFutures = (1 to 10).map { n =>
+        Document(s"range-$n", Map("range-id" -> n))
+      }.map { doc =>
+        restClient.index(index, tpe, doc)
+      }
+
+      val range = Future.sequence(rangeFutures)
+      whenReady(range) { _ =>
+        refresh()
+      }
+
+      val ltQuery = QueryRoot(RangeQuery("range-id", Lt("4")))
+      val ltFut = restClient.query(index, tpe, ltQuery)
+      whenReady(ltFut) { resp =>
+        resp should have length 3
+      }
+
+      val lteQuery = QueryRoot(RangeQuery("range-id", Lte("4")))
+      val lteFut = restClient.query(index, tpe, lteQuery)
+      whenReady(lteFut) { resp =>
+        resp should have length 4
+      }
+
+      val gtQuery = QueryRoot(RangeQuery("range-id", Gt("4")))
+      val gtFut = restClient.query(index, tpe, gtQuery)
+      whenReady(gtFut) { resp =>
+        resp should have length 6
+      }
+
+      val gteQuery = QueryRoot(RangeQuery("range-id", Gte("4")))
+      val gteFut = restClient.query(index, tpe, gteQuery)
+      whenReady(gteFut) { resp =>
+        resp should have length 7
+      }
+
+      val sliceQuery = QueryRoot(RangeQuery("range-id", Gte("5"), Lte("6")))
+      val sliceFut = restClient.query(index, tpe, sliceQuery)
+      whenReady(sliceFut) { resp =>
+        resp should have length 2
+      }
+    }
   }
 }
 

--- a/elasticsearch-test/pom.xml
+++ b/elasticsearch-test/pom.xml
@@ -4,7 +4,7 @@
   <artifactId>elasticsearch-test</artifactId>
   <name>elasticsearch-test</name>
   <packaging>jar</packaging>
-  <version>1.0.9-SNAPSHOT</version>
+  <version>1.0.11-SNAPSHOT</version>
   <scm><connection>scm:git:git@github.com:Sanyaku/sumologic.git/tags/all-1.0.4/sumologic.git</connection></scm>
 
   <properties>
@@ -16,7 +16,7 @@
   <parent>
     <artifactId>all</artifactId>
     <groupId>com.sumologic.elasticsearch</groupId>
-    <version>1.0.9-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
     <relativePath>../</relativePath>
   </parent>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <groupId>com.sumologic.elasticsearch</groupId>
     <artifactId>all</artifactId>
     <name>all</name>
-    <version>1.0.9-SNAPSHOT</version>
+    <version>1.0.11-SNAPSHOT</version>
     <packaging>pom</packaging>
     <licenses>
         <license>


### PR DESCRIPTION
Added a simple range query to the query DSL. `Range` takes a key and a list of bounds, each of which may be one of `Lt`, `Lte`, `Gt`, `Gte`.

No validation is performed; multiple of the same bound may be present. If no bounds are provided, an empty JSON object is generated, which was ignored by Elasticsearch 1.5.2.

Tested several generated JSON queries against my ElasticSearch cluster, worked fine.
