### PR TITLE
Bumping version of json4s to 3.3.0

### DIFF
--- a/elasticsearch-core/pom.xml
+++ b/elasticsearch-core/pom.xml
@@ -46,7 +46,7 @@
     <dependency>
       <groupId>org.json4s</groupId>
       <artifactId>json4s-native_${scala.version.major}</artifactId>
-      <version>3.2.11</version>
+      <version>3.3.0</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Why:
- other projects with newer version of json4s breaks this one at runtime
  - json4s is not binary compatible across major versions (e.g. 3.2.y and 3.3.x)
  - e.g. scala method with default arguments are source code compatible, but not binary compatible

Tests:
- [x] mvn test

Post-merge:
- [ ] release new version and start using it at Sumo Logic
