### PR TITLE
Support custom analyzer in index setting

### DIFF
--- a/elasticsearch-aws/src/test/scala/com/sumologic/elasticsearch/util/AwsRequestSignerTest.scala
+++ b/elasticsearch-aws/src/test/scala/com/sumologic/elasticsearch/util/AwsRequestSignerTest.scala
@@ -86,7 +86,7 @@ class AwsRequestSignerTest extends WordSpec with Matchers {
         host = "search-kwan-metrics-es-l2fecxdxfit54aod5dgpqchndq.us-east-1.es.amazonaws.com",
         path = "/metrics-catalog-index"
       ),
-      entity = HttpEntity(CreateIndex.toJsonStr)
+      entity = HttpEntity(CreateIndex().toJsonStr)
     )
 
     val expectedCanonical = "POST" +

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -120,8 +120,8 @@ class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[
     runEsCommand(mapping, s"/${index.name}/_mapping/${tpe.name}")
   }
 
-  def createIndex(index: Index): Future[RawJsonResponse] = {
-    runEsCommand(CreateIndex, s"/${index.name}").recover {
+  def createIndex(index: Index, settings: Option[IndexSetting] = None): Future[RawJsonResponse] = {
+    runEsCommand(CreateIndex(settings), s"/${index.name}").recover {
       case ElasticErrorResponse(message, status) if message contains "IndexAlreadyExistsException" =>
         throw new IndexAlreadyExistsException(message)
     }

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/DslCommons.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/DslCommons.scala
@@ -28,6 +28,10 @@ trait DslCommons {
     def toJson: Map[String, Any]
   }
 
+  trait FieldType {
+    val rep: String
+  }
+
   object EsOperation {
     implicit val formats = org.json4s.DefaultFormats
     def compactJson(map: Map[String, Any]) = compact(render(decompose(map)))
@@ -56,6 +60,8 @@ trait DslCommons {
   case class Index(name: String)
 
   case class Type(name: String)
+
+  case class Name(name: String)
 }
 
 

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/IndexDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/IndexDsl.scala
@@ -19,8 +19,12 @@
 package com.sumologic.elasticsearch.restlastic.dsl
 
 trait IndexDsl extends DslCommons {
-  case object CreateIndex extends RootObject {
-    override def toJson: Map[String, Any] = Map()
+  case class CreateIndex(settings: Option[IndexSetting] = None) extends RootObject {
+    val _settings = "settings"
+
+    override def toJson: Map[String, Any] = if (settings.nonEmpty) {
+      Map(_settings -> settings.get.toJson)
+    } else Map()
   }
 
   case class Document(id: String, data: Map[String, Any]) extends EsOperation with RootObject {
@@ -58,6 +62,36 @@ trait IndexDsl extends DslCommons {
       )
       s"${compactJson(jsonObjects)}\n${doc.toJsonStr}"
     }
+  }
+
+  case class IndexSetting(numberOfShards: Int, numberOfReplicas: Int, analyzer: Analyzer) extends EsOperation {
+    val _shards = "number_of_shards"
+    val _replicas = "number_of_replicas"
+    val _analysis = "analysis"
+
+    override def toJson: Map[String, Any] = Map(
+      _shards -> numberOfShards,
+      _replicas -> numberOfReplicas,
+      _analysis -> analyzer.toJson)
+  }
+
+  case class Analyzer(name: Name, tokenizer: FieldType, filter: FieldType) extends EsOperation {
+
+    val _analyzer = "analyzer"
+    val _tokenizer = "tokenizer"
+    val _filter = "filter"
+
+    override def toJson: Map[String, Any] = {
+      Map(_analyzer -> Map(name.name -> Map(_tokenizer -> tokenizer.rep, _filter -> filter.rep)))
+    }
+  }
+
+  case object Keyword extends FieldType {
+    val rep = "keyword"
+  }
+
+  case object Lowercase extends FieldType {
+    val rep = "lowercase"
   }
 }
 

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/MappingDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/MappingDsl.scala
@@ -20,10 +20,6 @@ package com.sumologic.elasticsearch.restlastic.dsl
 
 trait MappingDsl extends DslCommons {
 
-  sealed trait FieldType {
-    val rep: String
-  }
-
   case object StringType extends FieldType {
     val rep = "string"
   }
@@ -69,21 +65,20 @@ trait MappingDsl extends DslCommons {
   val _timestamp = "_timestamp"
   val _type = "type"
   val _index = "index"
+  val _analyzer = "analyzer"
 
-  case class BasicFieldMapping(tpe: FieldType, index: Option[IndexType]) extends FieldMapping {
-    override def toJson: Map[String, Any] = Map(_type -> tpe.rep) ++ index.map(_index -> _.rep).toList.toMap
+  case class BasicFieldMapping(tpe: FieldType, index: Option[IndexType], analyzer: Option[Name]) extends FieldMapping {
+    override def toJson: Map[String, Any] = Map(_type -> tpe.rep) ++ index.map(_index -> _.rep) ++ analyzer.map(_analyzer -> _.name).toList.toMap
   }
 
   case class BasicObjectMapping(fields: Map[String, FieldMapping]) extends FieldMapping {
     override def toJson: Map[String, Any] = Map(_properties -> fields.mapValues(_.toJson))
   }
 
-  case class CompletionMapping(context: Map[String, CompletionContext], caseSensitive: Boolean = true) extends FieldMapping {
+  case class CompletionMapping(context: Map[String, CompletionContext], analyzer: Name = Name("keyword")) extends FieldMapping {
     val _type = "type" -> "completion"
-    // simple analyzer does case insensitive autocomplete
-    val analyzer = if (caseSensitive) "keyword" else "simple"
-    val _analzyer = "analyzer" -> analyzer
-    val _sanalyzer = "search_analyzer" -> analyzer
+    val _analzyer = "analyzer" -> analyzer.name
+    val _sanalyzer = "search_analyzer" -> analyzer.name
     val _context = "context"
 
     override def toJson: Map[String, Any] = {

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -250,18 +250,18 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       whenReady(docFut) { _ => refresh() }
 
       // test lower case c
-      val autocompelteLower = restClient.suggest(index, tpe, Suggest("c", Completion("suggest", 50, Map("f" -> "test"))))
-      whenReady(autocompelteLower) {
+      val autocompleteLower = restClient.suggest(index, tpe, Suggest("c", Completion("suggest", 50, Map("f" -> "test"))))
+      whenReady(autocompleteLower) {
         resp => resp should be(List("Case", "case"))
       }
       // test upper case C
-      val autocompelteUpper = restClient.suggest(index, tpe, Suggest("C", Completion("suggest", 50, Map("f" -> "test"))))
-      whenReady(autocompelteUpper) {
+      val autocompleteUpper = restClient.suggest(index, tpe, Suggest("C", Completion("suggest", 50, Map("f" -> "test"))))
+      whenReady(autocompleteUpper) {
         resp => resp should be(List("Case", "case"))
       }
       // test special characters
-      val autocompelteSpecial = restClient.suggest(index, tpe, Suggest("#", Completion("suggest", 50, Map("f" -> "test"))))
-      whenReady(autocompelteSpecial) {
+      val autocompleteSpecial = restClient.suggest(index, tpe, Suggest("#", Completion("suggest", 50, Map("f" -> "test"))))
+      whenReady(autocompleteSpecial) {
         resp => resp should be(List("#Case`case"))
       }
     }

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -32,6 +32,7 @@ import scala.concurrent.{Await, Future}
 class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFutures with BeforeAndAfterAll with ElasticsearchIntegrationTest {
   val index = Index(IndexName)
   val tpe = Type("foo")
+  val analyzerName = Name("keyword_lowercase")
 
   import scala.concurrent.ExecutionContext.Implicits.global
   implicit val patience = PatienceConfig(timeout = scaled(Span(10, Seconds)), interval = scaled(Span(50, Millis)))
@@ -42,9 +43,26 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
   }
 
   "RestlasticSearchClient" should {
+    "Be able to create an index and setup index setting" in {
+      val analyzer = Analyzer(analyzerName, Keyword, Lowercase)
+      val indexSetting = IndexSetting(12, 1, analyzer)
+      val indexFut = restClient.createIndex(index, Some(indexSetting))
+      whenReady(indexFut) { _ => refresh() }
+    }
+
+    "Be able to setup document mapping" in {
+      val basicFiledMapping = BasicFieldMapping(StringType, None, Some(analyzerName))
+      val timestampMapping = EnabledFieldMapping(true)
+      val metadataMapping = Mapping(tpe, IndexMapping(
+        Map("name" -> basicFiledMapping, "f1" -> basicFiledMapping, "suggest" -> CompletionMapping(Map("f" -> CompletionContext("name")), analyzerName)),
+        timestampMapping))
+
+      val mappingFut = restClient.putMapping(index, tpe, metadataMapping)
+      whenReady(mappingFut) { _ => refresh() }
+    }
+
     "Be able to create an index, index a document, and search it" in {
       val ir = for {
-        _ <- restClient.createIndex(index)
         ir <- restClient.index(index, tpe, Document("doc1", Map("text" -> "here")))
       } yield {
           ir
@@ -220,16 +238,8 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
     }
 
     "Support case insensitive autocomplete" in {
-      val unanalyzedString = BasicFieldMapping(StringType, Some(NotAnalyzedIndex))
-      val timestampMapping = EnabledFieldMapping(true)
-      val metadataMapping = Mapping(tpe, IndexMapping(
-        Map("name" -> unanalyzedString, "suggest" -> CompletionMapping(Map("f" -> CompletionContext("name")), false)),
-        timestampMapping))
 
-      val mappingFut = restClient.putMapping(index, tpe, metadataMapping)
-      whenReady(mappingFut) { _ => refresh() }
-
-      val keyWords = List("Case", "case")
+      val keyWords = List("Case", "case", "#Case`case")
       val input = Map(
         "name" -> "test",
         "suggest" -> Map(
@@ -248,6 +258,22 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       val autocompelteUpper = restClient.suggest(index, tpe, Suggest("C", Completion("suggest", 50, Map("f" -> "test"))))
       whenReady(autocompelteUpper) {
         resp => resp should be(List("Case", "case"))
+      }
+      // test special characters
+      val autocompelteSpecial = restClient.suggest(index, tpe, Suggest("#", Completion("suggest", 50, Map("f" -> "test"))))
+      whenReady(autocompelteSpecial) {
+        resp => resp should be(List("#Case`case"))
+      }
+    }
+
+    "Suport case insensitive query" in {
+      val docLower = Document("caseinsensitivequerylower", Map("f1" -> "CaSe", "f2" -> 5))
+      val futLower = restClient.index(index, tpe, docLower)
+      whenReady(futLower) { _ => refresh() }
+      // WildcardQuery is not analyzed https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-wildcard-query.html
+      val resFutLower = restClient.query(index, tpe, QueryRoot(WildcardQuery("f1", "case")))
+      whenReady(resFutLower) { resp =>
+        resp.extractSource[DocType].head should be(DocType("CaSe", 5))
       }
     }
 


### PR DESCRIPTION
[x] Added support for custom index setting 
including
- [x] number of shards, replicas 
- [x] provide custom analyzer 

[x] Updated autocomplete interface to accept custom analyzer
- [x] default to previous behavior for backward compatibility

[x] Added unit tests for 
- [x] set up index setting
- [x] set up document mapping
- [x] case insensitive autocomplete with custom analyzer with special characters
- [x] case insensitive query with customer analyzer
