### PR TITLE
Combine multi-term filter query with bool-must

### DIFF
--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
@@ -62,12 +62,14 @@ trait QueryDsl extends DslCommons {
     val _filter = "filter"
     val _query = "query"
     val _searchType = "search-type"
+    val _bool = "bool"
+    val _must = "must"
 
     override def toJson: Map[String, Any] = {
       Map(
         _filtered -> Map(
           _query -> query.toJson,
-          _filter -> filter.map(_.toJson)
+          _filter -> Map(_bool -> Map(_must -> filter.map(_.toJson)))
         )
       )
     }

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -344,8 +344,6 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       whenReady(resFut2) { res =>
         res.sourceAsMap.toList should be(List())
       }
-
-      println(s"MultitermQuery: ${invalidQuery2.toJson}")
       val resFut3 = restClient.query(index, tpe, QueryRoot(invalidQuery2))
       whenReady(resFut3) { res =>
         res.sourceAsMap.toList should be(List())

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -335,12 +335,19 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       val termf3 = TermFilter("filter1", "val2")
       val validQuery = MultiTermFilteredQuery(MatchAll, termf1, termf2)
       val invalidQuery = MultiTermFilteredQuery(MatchAll, termf1, termf3)
+      val invalidQuery2 = MultiTermFilteredQuery(MatchAll, termf3, termf1)
       val resFut = restClient.query(index, tpe, QueryRoot(validQuery))
       whenReady(resFut) { res =>
         res.sourceAsMap.toList should be(List(Map("filter1" -> "val1", "filter2" -> "val2")))
       }
       val resFut2 = restClient.query(index, tpe, QueryRoot(invalidQuery))
       whenReady(resFut2) { res =>
+        res.sourceAsMap.toList should be(List())
+      }
+
+      println(s"MultitermQuery: ${invalidQuery2.toJson}")
+      val resFut3 = restClient.query(index, tpe, QueryRoot(invalidQuery2))
+      whenReady(resFut3) { res =>
         res.sourceAsMap.toList should be(List())
       }
     }


### PR DESCRIPTION
Previous multi-term query is not combined with bool-must and the behavior is that only the last term filter is always applied. 
 [x] Added bool must combinator
 [x] Updated unit test to add one more case
