### PR TITLE
Make execution context an argument for ScrollClient methods that crea…

### DIFF
--- a/elasticsearch-akka/src/test/scala/com/sumologic/elasticsearch/akkahelpers/BulkIndexerActorTest.scala
+++ b/elasticsearch-akka/src/test/scala/com/sumologic/elasticsearch/akkahelpers/BulkIndexerActorTest.scala
@@ -60,11 +60,11 @@ with BeforeAndAfterAll with BeforeAndAfterEach with MockitoSugar with ImplicitSe
   "BulkIndexerActor" should {
     "flush every message when set to 1" in {
       maxMessages = 1
-      when(mockEs.bulkIndex(any())).thenReturn(Future.successful(Seq(BulkItem("index","type", "_id", 201, None))))
+      when(mockEs.bulkIndex(any())(any())).thenReturn(Future.successful(Seq(BulkItem("index","type", "_id", 201, None))))
       val sess = BulkSession.create()
       indexerActor ! CreateRequest(sess, Index("i"), Type("tpe"), Document("id", Map("k" -> "v")))
       eventually {
-        mockEs.bulkIndex(any())
+        mockEs.bulkIndex(any())(any())
       }
       val msg = expectMsgType[DocumentIndexed]
       msg.sessionId should be(sess)

--- a/elasticsearch-akka/src/test/scala/com/sumologic/elasticsearch/akkahelpers/ScanAndScrollSourceTest.scala
+++ b/elasticsearch-akka/src/test/scala/com/sumologic/elasticsearch/akkahelpers/ScanAndScrollSourceTest.scala
@@ -30,7 +30,7 @@ import org.json4s._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{Matchers, WordSpec}
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 class ScanAndScrollSourceTest extends WordSpec with Matchers with ScalaFutures {
   val resultMaps: List[Map[String, AnyRef]] = List(Map("a" -> "1"), Map("a" -> "2"), Map("a" -> "3"))
@@ -69,7 +69,8 @@ class MockScrollClient(results: List[SearchResponse]) extends ScrollClient {
   var started = false
   var resultsQueue = results
   override def startScrollRequest(index: Dsl.Index, tpe: Dsl.Type, query: Dsl.QueryRoot,
-                                  resultWindow: String): Future[ScrollId] = {
+                                  resultWindow: String)
+                                 (implicit ec: ExecutionContext): Future[ScrollId] = {
     if (!started) {
       started = true
       Future.successful(ScrollId(id.toString))
@@ -78,7 +79,8 @@ class MockScrollClient(results: List[SearchResponse]) extends ScrollClient {
     }
   }
 
-  override def scroll(scrollId: ScrollId, resultWindow: String): Future[(ScrollId, SearchResponse)] = {
+  override def scroll(scrollId: ScrollId, resultWindow: String)
+                     (implicit ec: ExecutionContext): Future[(ScrollId, SearchResponse)] = {
     if (scrollId.id.toInt == id) {
       id += 1
       resultsQueue match {


### PR DESCRIPTION
…te a Future
This PR adds a new implicit argument to supply an `ExecutionContext` to all those `RestlasticSearchClient` methods which create a `Future`. 
