### PR TITLE
Added 2 default parameters to RestlasticSearchClient to provide searc…

### DIFF
--- a/elasticsearch-akka/src/test/scala/com/sumologic/elasticsearch/akkahelpers/BulkIndexerActorTest.scala
+++ b/elasticsearch-akka/src/test/scala/com/sumologic/elasticsearch/akkahelpers/BulkIndexerActorTest.scala
@@ -60,11 +60,11 @@ with BeforeAndAfterAll with BeforeAndAfterEach with MockitoSugar with ImplicitSe
   "BulkIndexerActor" should {
     "flush every message when set to 1" in {
       maxMessages = 1
-      when(mockEs.bulkIndex(any())(any())).thenReturn(Future.successful(Seq(BulkItem("index","type", "_id", 201, None))))
+      when(mockEs.bulkIndex(any())).thenReturn(Future.successful(Seq(BulkItem("index","type", "_id", 201, None))))
       val sess = BulkSession.create()
       indexerActor ! CreateRequest(sess, Index("i"), Type("tpe"), Document("id", Map("k" -> "v")))
       eventually {
-        mockEs.bulkIndex(any())(any())
+        mockEs.bulkIndex(any())
       }
       val msg = expectMsgType[DocumentIndexed]
       msg.sessionId should be(sess)

--- a/elasticsearch-akka/src/test/scala/com/sumologic/elasticsearch/akkahelpers/ScanAndScrollSourceTest.scala
+++ b/elasticsearch-akka/src/test/scala/com/sumologic/elasticsearch/akkahelpers/ScanAndScrollSourceTest.scala
@@ -30,7 +30,7 @@ import org.json4s._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{Matchers, WordSpec}
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.Future
 
 class ScanAndScrollSourceTest extends WordSpec with Matchers with ScalaFutures {
   val resultMaps: List[Map[String, AnyRef]] = List(Map("a" -> "1"), Map("a" -> "2"), Map("a" -> "3"))
@@ -69,8 +69,7 @@ class MockScrollClient(results: List[SearchResponse]) extends ScrollClient {
   var started = false
   var resultsQueue = results
   override def startScrollRequest(index: Dsl.Index, tpe: Dsl.Type, query: Dsl.QueryRoot,
-                                  resultWindow: String)
-                                 (implicit ec: ExecutionContext): Future[ScrollId] = {
+                                  resultWindow: String): Future[ScrollId] = {
     if (!started) {
       started = true
       Future.successful(ScrollId(id.toString))
@@ -79,8 +78,7 @@ class MockScrollClient(results: List[SearchResponse]) extends ScrollClient {
     }
   }
 
-  override def scroll(scrollId: ScrollId, resultWindow: String)
-                     (implicit ec: ExecutionContext): Future[(ScrollId, SearchResponse)] = {
+  override def scroll(scrollId: ScrollId, resultWindow: String): Future[(ScrollId, SearchResponse)] = {
     if (scrollId.id.toInt == id) {
       id += 1
       resultsQueue match {

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -37,10 +37,8 @@ import scala.concurrent.duration._
 
 trait ScrollClient {
   import Dsl._
-  def startScrollRequest(index: Index, tpe: Type, query: QueryRoot, resultWindow: String = "1m")
-                        (implicit ec: ExecutionContext): Future[ScrollId]
-  def scroll(scrollId: ScrollId, resultWindow: String = "1m")
-            (implicit ec: ExecutionContext): Future[(ScrollId, SearchResponse)]
+  def startScrollRequest(index: Index, tpe: Type, query: QueryRoot, resultWindow: String = "1m"): Future[ScrollId]
+  def scroll(scrollId: ScrollId, resultWindow: String = "1m"): Future[(ScrollId, SearchResponse)]
 }
 
 case class Endpoint(host: String, port: Int)
@@ -64,7 +62,10 @@ trait RequestSigner {
  * used by ElasticSearch.
  * @param endpointProvider EndpointProvider
  */
-class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[RequestSigner] = None) extends ScrollClient {
+class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[RequestSigner] = None,
+                             indexExecutionCtx: ExecutionContext = ExecutionContext.Implicits.global,
+                             searchExecutionCtx: ExecutionContext = ExecutionContext.Implicits.global)
+  extends ScrollClient {
 
   implicit val system: ActorSystem = ActorSystem()
   implicit val timeout: Timeout = Timeout(30.seconds)
@@ -74,14 +75,16 @@ class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[
   import RestlasticSearchClient.ReturnTypes._
 
   def ready: Boolean = endpointProvider.ready
-  def query(index: Index, tpe: Type, query: QueryRoot)(implicit ec: ExecutionContext): Future[SearchResponse] = {
+  def query(index: Index, tpe: Type, query: QueryRoot): Future[SearchResponse] = {
+    implicit val ec = searchExecutionCtx
     runEsCommand(query, s"/${index.name}/${tpe.name}/_search").map { rawJson =>
       SearchResponse(rawJson.mappedTo[RawSearchResponse], rawJson.jsonStr)
     }
   }
 
-  def suggest(index: Index, tpe: Type, query: Suggest)(implicit ec: ExecutionContext): Future[List[String]] = {
+  def suggest(index: Index, tpe: Type, query: Suggest): Future[List[String]] = {
     // I'm not totally sure why, but you don't specify the type for _suggest queries
+    implicit val ec = searchExecutionCtx
     val fut = runEsCommand(query, s"/${index.name}/_suggest")
     fut.map { resp =>
       val extracted = resp.mappedTo[SuggestResult]
@@ -89,64 +92,66 @@ class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[
     }
   }
 
-  def count(index: Index, tpe: Type, query: QueryRoot)(implicit ec: ExecutionContext): Future[Int] = {
+  def count(index: Index, tpe: Type, query: QueryRoot): Future[Int] = {
+    implicit val ec = searchExecutionCtx
     val fut = runEsCommand(query, s"/${index.name}/${tpe.name}/_count")
     fut.map(_.mappedTo[CountResponse].count)
   }
 
-  def index(index: Index, tpe: Type, doc: Document)(implicit ec: ExecutionContext): Future[IndexResponse] = {
+  def index(index: Index, tpe: Type, doc: Document): Future[IndexResponse] = {
+    implicit val ec = indexExecutionCtx
     runEsCommand(doc, s"/${index.name}/${tpe.name}/${doc.id}").map(_.mappedTo[IndexResponse])
 
   }
 
-  def bulkIndex(bulk: Bulk)(implicit ec: ExecutionContext): Future[Seq[BulkItem]] = {
+  def bulkIndex(bulk: Bulk): Future[Seq[BulkItem]] = {
+    implicit val ec = indexExecutionCtx
     runEsCommand(bulk, s"/_bulk").map { resp =>
       val bulkResp = resp.mappedTo[BulkIndexResponse]
       bulkResp.items.map(_.values.head)
     }
   }
 
-  def bulkIndex(index: Index, tpe: Type, documents: Seq[Document])
-               (implicit ec: ExecutionContext): Future[Seq[BulkItem]] = {
+  def bulkIndex(index: Index, tpe: Type, documents: Seq[Document]): Future[Seq[BulkItem]] = {
     val bulkOperation = Bulk(documents.map(BulkOperation(create, Some(index -> tpe), _)))
     bulkIndex(bulkOperation)
   }
 
-  def bulkUpdate(index: Index, tpe: Type, documents: Seq[Document])
-                (implicit ec: ExecutionContext): Future[Seq[BulkItem]] = {
+  def bulkUpdate(index: Index, tpe: Type, documents: Seq[Document]): Future[Seq[BulkItem]] = {
     val bulkOperation = Bulk(documents.map(BulkOperation(update, Some(index -> tpe), _)))
     bulkIndex(bulkOperation)
   }
 
-  def putMapping(index: Index, tpe: Type, mapping: Mapping)
-                (implicit ec: ExecutionContext): Future[RawJsonResponse] = {
+  def putMapping(index: Index, tpe: Type, mapping: Mapping): Future[RawJsonResponse] = {
+    implicit val ec = indexExecutionCtx
     runEsCommand(mapping, s"/${index.name}/_mapping/${tpe.name}")
   }
 
-  def getMapping(index: Index, tpe: Type)
-                (implicit ec: ExecutionContext): Future[RawJsonResponse] = {
+  def getMapping(index: Index, tpe: Type): Future[RawJsonResponse] = {
+    implicit val ec = searchExecutionCtx
     runEsCommand(EmptyObject, s"/${index.name}/_mapping/${tpe.name}", GET)
   }
 
-  def createIndex(index: Index, settings: Option[IndexSetting] = None)
-                 (implicit ec: ExecutionContext): Future[RawJsonResponse] = {
+  def createIndex(index: Index, settings: Option[IndexSetting] = None): Future[RawJsonResponse] = {
+    implicit val ec = indexExecutionCtx
     runEsCommand(CreateIndex(settings), s"/${index.name}").recover {
       case ElasticErrorResponse(message, status) if message contains "IndexAlreadyExistsException" =>
         throw new IndexAlreadyExistsException(message)
     }
   }
 
-  def deleteIndex(index: Index)(implicit ec: ExecutionContext): Future[RawJsonResponse] = {
+  def deleteIndex(index: Index): Future[RawJsonResponse] = {
+    implicit val ec = indexExecutionCtx
     runEsCommand(EmptyObject, s"/${index.name}", DELETE)
   }
 
-  def deleteDocument(index: Index, tpe: Type, query: QueryRoot)
-                    (implicit ec: ExecutionContext): Future[RawJsonResponse] = {
+  def deleteDocument(index: Index, tpe: Type, query: QueryRoot): Future[RawJsonResponse] = {
+    implicit val ec = indexExecutionCtx
     runEsCommand(query, s"/${index.name}/${tpe.name}/_query", DELETE)
   }
 
-  def startScrollRequest(index: Index, tpe: Type, query: QueryRoot, resultWindow: String = "1m")
-                        (implicit ec: ExecutionContext): Future[ScrollId] = {
+  def startScrollRequest(index: Index, tpe: Type, query: QueryRoot, resultWindow: String = "1m"): Future[ScrollId] = {
+    implicit val ec = searchExecutionCtx
     val uriQuery = UriQuery("scroll" -> resultWindow, "search_type" -> "scan")
     runEsCommand(query, s"/${index.name}/${tpe.name}/_search", query = uriQuery).map { resp =>
       val parsed = resp.mappedTo[ScrollResponse]
@@ -154,8 +159,8 @@ class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[
     }
   }
 
-  def scroll(scrollId: ScrollId, resultWindow: String = "1m")
-            (implicit ec: ExecutionContext): Future[(ScrollId, SearchResponse)] = {
+  def scroll(scrollId: ScrollId, resultWindow: String = "1m"): Future[(ScrollId, SearchResponse)] = {
+    implicit val ec = searchExecutionCtx
     val uriQuery = UriQuery("scroll_id" -> scrollId.id, "scroll" -> resultWindow)
     runEsCommand(NoOp, s"/_search/scroll", query = uriQuery).map { resp =>
       val sr = resp.mappedTo[SearchResponseWithScrollId]
@@ -163,11 +168,13 @@ class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[
     }
   }
 
-  def flush(index: Index)(implicit ec: ExecutionContext): Future[RawJsonResponse] = {
+  def flush(index: Index): Future[RawJsonResponse] = {
+    implicit val ec = indexExecutionCtx
     runEsCommand(EmptyObject, s"/${index.name}/_flush")
   }
 
-  def refresh(index: Index)(implicit ec: ExecutionContext): Future[RawJsonResponse] = {
+  def refresh(index: Index): Future[RawJsonResponse] = {
+    implicit val ec = indexExecutionCtx
     runEsCommand(EmptyObject, s"/${index.name}/_refresh")
   }
 
@@ -183,7 +190,7 @@ class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[
                       endpoint: String,
                       method: HttpMethod = POST,
                       query: UriQuery = UriQuery.Empty)
-                     (implicit ec: ExecutionContext): Future[RawJsonResponse] = {
+                     (implicit ec: ExecutionContext = ExecutionContext.Implicits.global): Future[RawJsonResponse] = {
     val request = {
       val unauthed = HttpRequest(
         method = method,


### PR DESCRIPTION
…h and index thread-pools

This PR is an attempt at fixing backward compatibility that got broken by an earlier [commit](https://github.com/SumoLogic/elasticsearch-client/pull/30/commits/8bda63cb1886c0803296984555783f70db25138b) of mine.

Following @rcoh 's idea of adding execution context as a default parameter to `RestlasticSearchClient`, I have added 2 such parameters for execution contexts to be used for indexing and search.

This has allowed me to revert all `RestlasticClient`'s methods to either their original form (that doesn't require the additional execution context parameter), or, in case of `runRawEsRequest`, to admit a default value for that parameter.

The `ScrollClient` trait has also been reinstated to its original form.

I believe that with these changes, it should be possible to publish `elasticsearch-client` with only a patch-number bump.

Many thanks to @rcoh and @cddude229 for suggestions and help. @cddude229 Could you please review it once more.
