### PR TITLE
Revert "Add refresh interval index setting and support same key multi values in completion context"

### DIFF
--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/CompletionDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/CompletionDsl.scala
@@ -18,12 +18,9 @@
  */
 package com.sumologic.elasticsearch.restlastic.dsl
 
-import org.json4s.JsonAST.JObject
-import org.json4s.JsonDSL._
-
 trait CompletionDsl extends DslCommons with QueryDsl {
 
-  case class Suggest(text: String, completion: CompletionWithContext) extends Query with RootObject {
+  case class Suggest(text: String, completion: Completion) extends Query with RootObject {
     val _suggest = "suggest"
     val _text = "text"
     val _completion = "completion"
@@ -36,40 +33,20 @@ trait CompletionDsl extends DslCommons with QueryDsl {
     }
   }
 
-  trait CompletionWithContext {
+  case class Completion(field: String, size: Int, context: Map[String, String]) extends Query {
     val _field = "field"
     val _context = "context"
     val _size = "size"
 
-    val field: String
-    val size: Int
-    def context: Iterable[(String, String)]
+    def withAdditionalContext(newContext: (String, String)*) = {
+      this.copy(context = context ++ newContext)
+    }
 
-    def toJson: Map[String, Any] = Map(
+    override def toJson: Map[String, Any] = Map(
       _field -> field,
-      _context -> context.foldLeft(JObject()) {(k, v) => k ~ v },
+      _context -> context,
       _size -> size
     )
-  }
-
-  case class Completion(field: String, size: Int, context: Map[String, String])
-    extends Query with CompletionWithContext {
-
-    def withAdditionalContext(newContext: (String, String)*) = {
-      this.copy(context = context ++ newContext)
-    }
-  }
-
-  /**
-   * Support context filters with same key and different values
-   * e.g. context: key->val1, key->val2
-   */
-  case class CompletionWithSeqContext(field: String, size: Int, context: Seq[(String, String)])
-    extends Query with CompletionWithContext {
-
-    def withAdditionalContext(newContext: (String, String)*) = {
-      this.copy(context = context ++ newContext)
-    }
   }
 }
 

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/IndexDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/IndexDsl.scala
@@ -64,17 +64,15 @@ trait IndexDsl extends DslCommons {
     }
   }
 
-  case class IndexSetting(numberOfShards: Int, numberOfReplicas: Int, analyzer: Analyzer, refreshInterval: Int = 1) extends EsOperation {
+  case class IndexSetting(numberOfShards: Int, numberOfReplicas: Int, analyzer: Analyzer) extends EsOperation {
     val _shards = "number_of_shards"
     val _replicas = "number_of_replicas"
     val _analysis = "analysis"
-    val _refreshInterval = "refresh_interval"
 
     override def toJson: Map[String, Any] = Map(
       _shards -> numberOfShards,
       _replicas -> numberOfReplicas,
-      _analysis -> analyzer.toJson,
-      _refreshInterval -> refreshInterval)
+      _analysis -> analyzer.toJson)
   }
 
   case class Analyzer(name: Name, tokenizer: FieldType, filter: FieldType) extends EsOperation {

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -265,21 +265,17 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       whenReady(docFut) { _ => refresh() }
 
       // test lower case c
-      val autocompleteLower = restClient.suggest(index, tpe, Suggest("c",
-        Completion("suggest", 50, Map("f" -> "test"))))
+      val autocompleteLower = restClient.suggest(index, tpe, Suggest("c", Completion("suggest", 50, Map("f" -> "test"))))
       whenReady(autocompleteLower) {
         resp => resp should be(List("Case", "case"))
       }
       // test upper case C
-      val autocompleteUpper = restClient.suggest(index, tpe, Suggest("C",
-        CompletionWithSeqContext("suggest", 50, Seq("f" -> "test"))))
+      val autocompleteUpper = restClient.suggest(index, tpe, Suggest("C", Completion("suggest", 50, Map("f" -> "test"))))
       whenReady(autocompleteUpper) {
         resp => resp should be(List("Case", "case"))
       }
       // test special characters
-      val autocompleteSpecial = restClient.suggest(index, tpe, Suggest("#",
-        CompletionWithSeqContext("suggest", 50, Seq("f" -> "test")).
-          withAdditionalContext("f" -> "test")))
+      val autocompleteSpecial = restClient.suggest(index, tpe, Suggest("#", Completion("suggest", 50, Map("f" -> "test"))))
       whenReady(autocompleteSpecial) {
         resp => resp should be(List("#Case`case"))
       }


### PR DESCRIPTION
Reverts SumoLogic/elasticsearch-client#36

Contexts is only supported in a much later version of ES. Currently it accepts multiple filters with same key. But only the last one is executed. Revert it to avoid confusion. 
