### PR TITLE
Add optoin of refresh interval in index settings & allow context aware autocomplete without extraction from path

### DIFF
--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/IndexDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/IndexDsl.scala
@@ -64,15 +64,17 @@ trait IndexDsl extends DslCommons {
     }
   }
 
-  case class IndexSetting(numberOfShards: Int, numberOfReplicas: Int, analyzer: Analyzer) extends EsOperation {
+  case class IndexSetting(numberOfShards: Int, numberOfReplicas: Int, analyzer: Analyzer, refreshInterval: Int = 1) extends EsOperation {
     val _shards = "number_of_shards"
     val _replicas = "number_of_replicas"
     val _analysis = "analysis"
+    val _interval = "refresh_interval"
 
     override def toJson: Map[String, Any] = Map(
       _shards -> numberOfShards,
       _replicas -> numberOfReplicas,
-      _analysis -> analyzer.toJson)
+      _analysis -> analyzer.toJson,
+      _interval -> s"${refreshInterval}s")
   }
 
   case class Analyzer(name: Name, tokenizer: FieldType, filter: FieldType) extends EsOperation {

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/MappingDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/MappingDsl.scala
@@ -114,23 +114,46 @@ trait MappingDsl extends DslCommons {
     override def toJson: Map[String, Any] = Map(_properties -> fields.mapValues(_.toJson))
   }
 
-  case class CompletionMapping(context: Map[String, CompletionContext], analyzer: Name = Name("keyword")) extends FieldMapping {
+  trait Completion {
     val _type = "type" -> "completion"
+    val _context = "context"
     val _analzyer = "analyzer" -> analyzer.name
     val _sanalyzer = "search_analyzer" -> analyzer.name
-    val _context = "context"
 
-    override def toJson: Map[String, Any] = {
+    def analyzer: Name
+
+    def toJson: Map[String, Any] = {
       Map(
         _type,
         _analzyer,
-        _sanalyzer,
-        _context -> context.mapValues { case cc =>
+        _sanalyzer)
+    }
+  }
+
+  case class CompletionMapping(context: Map[String, CompletionContext], analyzer: Name = Name("keyword"))
+    extends FieldMapping with Completion {
+
+    override def toJson: Map[String, Any] = {
+      super.toJson ++
+      Map(_context -> context.mapValues { case cc =>
           Map(
             "type" -> "category",
             "path" -> cc.path
           )
         }
+      )
+    }
+  }
+
+  case class CompletionMappingWithoutPath(context: String, analyzer: Name = Name("keyword"))
+    extends FieldMapping with Completion {
+
+    override def toJson: Map[String, Any] = {
+      super.toJson ++
+      Map(_context ->
+        Map(context ->
+          Map("type" -> "category")
+        )
       )
     }
   }

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -49,7 +49,7 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
   "RestlasticSearchClient" should {
     "Be able to create an index and setup index setting" in {
       val analyzer = Analyzer(analyzerName, Keyword, Lowercase)
-      val indexSetting = IndexSetting(12, 1, analyzer)
+      val indexSetting = IndexSetting(12, 1, analyzer, 30)
       val indexFut = restClient.createIndex(index, Some(indexSetting))
       whenReady(indexFut) { _ => refreshWithClient() }
     }
@@ -58,7 +58,7 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       val basicFiledMapping = BasicFieldMapping(StringType, None, Some(analyzerName))
       val timestampMapping = EnabledFieldMapping(true)
       val metadataMapping = Mapping(tpe, IndexMapping(
-        Map("name" -> basicFiledMapping, "f1" -> basicFiledMapping, "suggest" -> CompletionMappingWithoutPath("f", analyzerName)),
+        Map("name" -> basicFiledMapping, "f1" -> basicFiledMapping, "suggest" -> CompletionMapping(Map("f" -> CompletionContext("name")), analyzerName)),
         timestampMapping))
 
       val mappingFut = restClient.putMapping(index, tpe, metadataMapping)
@@ -69,7 +69,7 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       val basicFiledMapping = BasicFieldMapping(StringType, None, Some(analyzerName), ignoreAbove = Some(10000))
       val timestampMapping = EnabledFieldMapping(true)
       val metadataMapping = Mapping(tpe, IndexMapping(
-        Map("name" -> basicFiledMapping, "f1" -> basicFiledMapping, "suggest" -> CompletionMappingWithoutPath("f", analyzerName)),
+        Map("name" -> basicFiledMapping, "f1" -> basicFiledMapping, "suggest" -> CompletionMapping(Map("f" -> CompletionContext("name")), analyzerName)),
         timestampMapping))
 
       val mappingFut = restClient.putMapping(index, tpe, metadataMapping)

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -265,21 +265,17 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       whenReady(docFut) { _ => refresh() }
 
       // test lower case c
-      val autocompleteLower = restClient.suggest(index, tpe, Suggest("c",
-        Completion("suggest", 50, Map("f" -> "test"))))
+      val autocompleteLower = restClient.suggest(index, tpe, Suggest("c", Completion("suggest", 50, Map("f" -> "test"))))
       whenReady(autocompleteLower) {
         resp => resp should be(List("Case", "case"))
       }
       // test upper case C
-      val autocompleteUpper = restClient.suggest(index, tpe, Suggest("C",
-        CompletionWithSeqContext("suggest", 50, Seq("f" -> "test"))))
+      val autocompleteUpper = restClient.suggest(index, tpe, Suggest("C", Completion("suggest", 50, Map("f" -> "test"))))
       whenReady(autocompleteUpper) {
         resp => resp should be(List("Case", "case"))
       }
       // test special characters
-      val autocompleteSpecial = restClient.suggest(index, tpe, Suggest("#",
-        CompletionWithSeqContext("suggest", 50, Seq("f" -> "test")).
-          withAdditionalContext("f" -> "test")))
+      val autocompleteSpecial = restClient.suggest(index, tpe, Suggest("#", Completion("suggest", 50, Map("f" -> "test"))))
       whenReady(autocompleteSpecial) {
         resp => resp should be(List("#Case`case"))
       }


### PR DESCRIPTION
- Add optoin of refresh interval in index settings 
- Allow context aware autocomplete without extraction from path

We find the extraction at ingest time is very time consuming. Without the extraction, we can have 5x ingest performance boost. Therefore, we remove the extraction and statically supply all the contexts.
