### PR TITLE
Multi Match Query support

### DIFF
--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
@@ -249,4 +249,17 @@ trait QueryDsl extends DslCommons {
     val _matchAll = "match_all"
     override def toJson: Map[String, Any] = Map(_matchAll -> Map())
   }
+
+  case class MultiMatchQuery(query: String, fields: String*) extends Query {
+    val _multiMatch = "multi_match"
+    val _query = "query"
+    val _fields = "fields"
+
+    override def toJson: Map[String, Any] = Map(
+      _multiMatch -> Map(
+        _query -> query,
+        _fields -> fields.toList
+      )
+    )
+  }
 }

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -487,14 +487,14 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
 
     "support multi match query" in {
       // https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html
-      val regexDoc1 = Document("multiMatchQueryDoc1", Map("f1" -> "multimatch1", "f2" -> 1, "text" -> "text1"))
-      val regexDoc2 = Document("multiMatchQueryDoc2", Map("f1" -> "text1", "f2" -> 1, "text" -> "multimatch1"))
-      val regexFuture = restClient.bulkIndex(index, tpe, Seq(regexDoc1, regexDoc2))
-      whenReady(regexFuture) { _ => refresh() }
+      val multiMatchDoc1 = Document("multiMatchDoc1", Map("f1" -> "multimatch1", "f2" -> 1, "text" -> "text1"))
+      val multiMatchDoc2 = Document("multiMatchDoc2", Map("f1" -> "text1", "f2" -> 1, "text" -> "multimatch1"))
+      val docsFuture = restClient.bulkIndex(index, tpe, Seq(multiMatchDoc1, multiMatchDoc2))
+      whenReady(docsFuture) { _ => refresh() }
 
-      val filteredQuery = MultiMatchQuery("multimatch1", "f1", "text")
-      val regexQueryFuture = restClient.query(index, tpe, QueryRoot(filteredQuery))
-      regexQueryFuture.futureValue.sourceAsMap should be(List(Map("f1" -> "text1", "f2" -> 1, "text" -> "multimatch1"), Map("f1" -> "multimatch1", "f2" -> 1, "text" -> "text1")))
+      val matchQuery = MultiMatchQuery("multimatch1", "f1", "text")
+      val matchQueryFuture = restClient.query(index, tpe, QueryRoot(matchQuery))
+      matchQueryFuture.futureValue.sourceAsMap should be(List(Map("f1" -> "text1", "f2" -> 1, "text" -> "multimatch1"), Map("f1" -> "multimatch1", "f2" -> 1, "text" -> "text1")))
     }
   }
 }

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -484,6 +484,18 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       val regexQueryFuture2 = restClient.query(index, tpe, QueryRoot(filteredQuery2))
       regexQueryFuture2.futureValue.sourceAsMap.toSet should be(Set(Map("f1" -> "regexFilter1", "f2" -> 1, "text" -> "text1"),  Map("f1" -> "regexFilter2", "f2" -> 1, "text" -> "text2")))
     }
+
+    "support multi match query" in {
+      // https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html
+      val regexDoc1 = Document("multiMatchQueryDoc1", Map("f1" -> "multimatch1", "f2" -> 1, "text" -> "text1"))
+      val regexDoc2 = Document("multiMatchQueryDoc2", Map("f1" -> "text1", "f2" -> 1, "text" -> "multimatch1"))
+      val regexFuture = restClient.bulkIndex(index, tpe, Seq(regexDoc1, regexDoc2))
+      whenReady(regexFuture) { _ => refresh() }
+
+      val filteredQuery = MultiMatchQuery("multimatch1", "f1", "text")
+      val regexQueryFuture = restClient.query(index, tpe, QueryRoot(filteredQuery))
+      regexQueryFuture.futureValue.sourceAsMap should be(List(Map("f1" -> "text1", "f2" -> 1, "text" -> "multimatch1"), Map("f1" -> "multimatch1", "f2" -> 1, "text" -> "text1")))
+    }
   }
 }
 


### PR DESCRIPTION
The `multi_match` query builds on the match query to allow multi-field queries
https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html

PR for #58 
