### PR TITLE
BucketAggregation with nesting buckets inside other buckets

### DIFF
--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -83,10 +83,10 @@ class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[
     }
   }
 
-  def bucketAggregation(index: Index, tpe: Type, query: AggregationQuery): Future[BucketAggregationResultBody] = {
+  def bucketAggregation(index: Index, tpe: Type, query: AggregationQuery): Future[Bucket] = {
     implicit val ec = searchExecutionCtx
     runEsCommand(query, s"/${index.name}/${tpe.name}/_search").map { rawJson =>
-      rawJson.mappedTo[BucketAggregationResponse].aggregations.aggs_name
+      Bucket(rawJson.mappedTo[BucketAggregationResponse].aggregations._2)
     }
   }
 
@@ -271,12 +271,13 @@ object RestlasticSearchClient {
       def sourceAsMap: Seq[Map[String, Any]] = hits.hits.map(_._source.values)
     }
 
+    case class Bucket(underlying: BucketMap)
+    type BucketMap = Map[String, Any]
+    type Aggregations = (String, BucketMap)
     case class BucketAggregationResponse(aggregations: Aggregations)
-    case class Aggregations(aggs_name: BucketAggregationResultBody )
     case class BucketAggregationResultBody(doc_count_error_upper_bound: Int,
                                            sum_other_doc_count: Int,
-                                           buckets: List[Bucket])
-    case class Bucket(key: String, doc_count: Int)
+                                           buckets: List[BucketMap])
 
     case class Hits(hits: List[ElasticJsonDocument], total: Int = 0)
     case class ElasticJsonDocument(_index: String,

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/AggregationDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/AggregationDsl.scala
@@ -40,26 +40,46 @@ trait AggregationDsl extends DslCommons with QueryDsl {
 
   case class TermsAggregation(field: String, include: Option[String],
                               size: Option[Int], shardSize: Option[Int],
-                              hint: Option[String] = None)
+                              hint: Option[String] = None,
+                              name: Option[String] = None,
+                              aggs: Option[Aggregation] = None)
     extends Aggregation {
 
-    val _aggsName = "aggs_name"
+    val _aggsName = name.getOrElse("aggs_name")
     val _terms = "terms"
     val _field = "field"
     val _include = "include"
     val _size = "size"
     val _shardSize = "shard_size"
     val _hint = "execution_hint"
+    val _aggs = "aggs"
 
     override def toJson: Map[String, Any] = {
       Map(_aggsName ->
-        Map(_terms ->
+        (Map(_terms ->
           (Map(_field -> field)
             ++ include.map(_include -> _)
             ++ size.map(_size -> _)
             ++ shardSize.map(_shardSize -> _)
-            ++ hint.map(_hint -> _))
-        )
+            ++ hint.map(_hint -> _)))
+        ++ aggs.map(_aggs -> _.toJson))
+      )
+    }
+  }
+
+  case class NestedAggregation(path: String, name: Option[String] = None, aggs: Option[Aggregation] = None)
+    extends Aggregation {
+
+    val _aggsName = name.getOrElse("aggs_name")
+    val _nested = "nested"
+    val _path = "path"
+    val _aggs = "aggs"
+
+    override def toJson: Map[String, Any] = {
+      Map(_aggsName ->
+        (Map(_nested ->
+        Map(_path -> path))
+          ++ aggs.map(_aggs -> _.toJson))
       )
     }
   }

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/BucketAggregationResponseTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/BucketAggregationResponseTest.scala
@@ -1,0 +1,66 @@
+package com.sumologic.elasticsearch.restlastic
+
+import com.sumologic.elasticsearch.restlastic.RestlasticSearchClient.ReturnTypes.{BucketAggregationResponse, RawJsonResponse}
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{Matchers, WordSpec}
+
+class BucketAggregationResponseTest extends WordSpec with Matchers with ScalaFutures {
+
+  "BucketAggregationResponse" should {
+    "parse buckets inside buckets" in {
+      val expected = Map(
+        "doc_count_error_upper_bound" -> 0,
+        "sum_other_doc_count" -> 0,
+        "buckets" -> List(Map(
+          "key" -> "honda",
+          "doc_count" -> 3,
+          "color" -> Map(
+            "doc_count_error_upper_bound" -> 0,
+            "sum_other_doc_count" -> 0,
+            "buckets" -> List(Map(
+              "key" -> "black",
+              "doc_count" -> 2), Map(
+              "key" -> "red",
+              "doc_count" -> 1)))))
+      )
+      RawJsonResponse(aggregationsBucketsInsideBuckets).mappedTo[BucketAggregationResponse].aggregations._2 should be(expected)
+    }
+  }
+
+  val aggregationsBucketsInsideBuckets =
+    """{
+    	"took": 3,
+    	"timed_out": false,
+    	"_shards": {
+    		"total": 12,
+    		"successful": 12,
+    		"failed": 0
+    	},
+    	"hits": {
+    		"total": 45,
+    		"max_score": 0.0,
+    		"hits": []
+    	},
+    	"aggregations": {
+    		"make": {
+    			"doc_count_error_upper_bound": 0,
+    			"sum_other_doc_count": 0,
+    			"buckets": [{
+    				"key": "honda",
+    				"doc_count": 3,
+    				"color": {
+    					"doc_count_error_upper_bound": 0,
+    					"sum_other_doc_count": 0,
+    					"buckets": [{
+    						"key": "black",
+    						"doc_count": 2
+    					}, {
+    						"key": "red",
+    						"doc_count": 1
+    					}]
+    				}
+    			}]
+    		}
+    	}
+    }"""
+}

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/BucketNestedAggregationResponseTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/BucketNestedAggregationResponseTest.scala
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.sumologic.elasticsearch.restlastic
 
 import com.sumologic.elasticsearch.restlastic.RestlasticSearchClient.ReturnTypes.{BucketNestedAggregationResponse, RawJsonResponse}

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/BucketNestedAggregationResponseTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/BucketNestedAggregationResponseTest.scala
@@ -1,10 +1,10 @@
 package com.sumologic.elasticsearch.restlastic
 
-import com.sumologic.elasticsearch.restlastic.RestlasticSearchClient.ReturnTypes.{BucketAggregationResponse, RawJsonResponse}
+import com.sumologic.elasticsearch.restlastic.RestlasticSearchClient.ReturnTypes.{BucketNestedAggregationResponse, RawJsonResponse}
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{Matchers, WordSpec}
 
-class BucketAggregationResponseTest extends WordSpec with Matchers with ScalaFutures {
+class BucketNestedAggregationResponseTest extends WordSpec with Matchers with ScalaFutures {
 
   "BucketAggregationResponse" should {
     "parse buckets inside buckets" in {
@@ -23,7 +23,7 @@ class BucketAggregationResponseTest extends WordSpec with Matchers with ScalaFut
               "key" -> "red",
               "doc_count" -> 1)))))
       )
-      RawJsonResponse(aggregationsBucketsInsideBuckets).mappedTo[BucketAggregationResponse].aggregations._2 should be(expected)
+      RawJsonResponse(aggregationsBucketsInsideBuckets).mappedTo[BucketNestedAggregationResponse].aggregations._2 should be(expected)
     }
   }
 

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -443,7 +443,7 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       val termsAggr = TermsAggregation("f1", Some("aggr.*"), Some(5), Some(5), Some("map"))
       val aggrQuery = AggregationQuery(filteredQuery, termsAggr, Some(1000))
 
-      val expected = BucketAggregationResultBody(0, 0, List(Bucket("aggr1", 1), Bucket("aggr3", 1)))
+      val expected = Bucket(Map("doc_count_error_upper_bound" -> 0, "sum_other_doc_count" -> 0, "buckets" -> List(Map("key" -> "aggr1", "doc_count" -> 1), Map("key" -> "aggr3", "doc_count" -> 1))))
 
       val aggrQueryFuture = restClient.bucketAggregation(index, tpe, aggrQuery)
       aggrQueryFuture.futureValue should be (expected)
@@ -483,6 +483,29 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       val filteredQuery2 = MultiTermFilteredQuery(MatchAll, RegexFilter("f1", "regexf.*"))
       val regexQueryFuture2 = restClient.query(index, tpe, QueryRoot(filteredQuery2))
       regexQueryFuture2.futureValue.sourceAsMap.toSet should be(Set(Map("f1" -> "regexFilter1", "f2" -> 1, "text" -> "text1"),  Map("f1" -> "regexFilter2", "f2" -> 1, "text" -> "text2")))
+    }
+
+    "support buckets inside buckets" in {
+      // https://www.elastic.co/guide/en/elasticsearch/guide/current/_buckets_inside_buckets.html
+      val doc1 = Document("agg_doc1", Map("make" -> "honda", "color" -> "red"))
+      val doc2 = Document("agg_doc2", Map("make" -> "honda", "color" -> "black"))
+      val doc3 = Document("agg_doc3", Map("make" -> "honda", "color" -> "black"))
+      val regexFuture = restClient.bulkIndex(index, tpe, Seq(doc1, doc2, doc3))
+      whenReady(regexFuture) { _ => refresh() }
+
+      val aggregations = TermsAggregation(name = Some("make"), field = "make", include = None, size = Some(0), shardSize = None, hint = None,
+        aggs = Some(TermsAggregation(name = Some("color"), field = "color", include = None, size = Some(0), shardSize = None, hint = None))
+      )
+
+      val aggregationsQuery =AggregationQuery(
+        query = MatchAll,
+        aggs = aggregations,
+        timeout = None
+      )
+
+      val expected = Bucket(Map("doc_count_error_upper_bound" -> 0, "sum_other_doc_count" -> 0, "buckets" -> List(Map("key" -> "honda", "doc_count" -> 3, "color" -> Map("doc_count_error_upper_bound" -> 0, "sum_other_doc_count" -> 0, "buckets" -> List(Map("key" -> "black", "doc_count" -> 2), Map("key" -> "red", "doc_count" -> 1)))))))
+      val aggregationsQueryFuture = restClient.bucketAggregation(index, tpe, aggregationsQuery)
+      aggregationsQueryFuture.futureValue should be(expected)
     }
   }
 }

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -18,7 +18,7 @@
  */
 package com.sumologic.elasticsearch.restlastic
 
-import com.sumologic.elasticsearch.restlastic.RestlasticSearchClient.ReturnTypes.{Bucket, BucketAggregationResultBody, IndexAlreadyExistsException}
+import com.sumologic.elasticsearch.restlastic.RestlasticSearchClient.ReturnTypes._
 import spray.http.HttpMethods._
 import com.sumologic.elasticsearch.restlastic.dsl.Dsl._
 import com.sumologic.elasticsearch_test.ElasticsearchIntegrationTest
@@ -444,7 +444,7 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       val termsAggr = TermsAggregation("f1", Some("aggr.*"), Some(5), Some(5), Some("map"))
       val aggrQuery = AggregationQuery(filteredQuery, termsAggr, Some(1000))
 
-      val expected = Bucket(Map("doc_count_error_upper_bound" -> 0, "sum_other_doc_count" -> 0, "buckets" -> List(Map("key" -> "aggr1", "doc_count" -> 1), Map("key" -> "aggr3", "doc_count" -> 1))))
+      val expected = BucketAggregationResultBody(0, 0, List(Bucket("aggr1", 1), Bucket("aggr3", 1)))
 
       val aggrQueryFuture = restClient.bucketAggregation(index, tpe, aggrQuery)
       aggrQueryFuture.futureValue should be (expected)
@@ -504,8 +504,8 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
         timeout = None
       )
 
-      val expected = Bucket(Map("doc_count_error_upper_bound" -> 0, "sum_other_doc_count" -> 0, "buckets" -> List(Map("key" -> "honda", "doc_count" -> 3, "color" -> Map("doc_count_error_upper_bound" -> 0, "sum_other_doc_count" -> 0, "buckets" -> List(Map("key" -> "black", "doc_count" -> 2), Map("key" -> "red", "doc_count" -> 1)))))))
-      val aggregationsQueryFuture = restClient.bucketAggregation(index, tpe, aggregationsQuery)
+      val expected = BucketNested(Map("doc_count_error_upper_bound" -> 0, "sum_other_doc_count" -> 0, "buckets" -> List(Map("key" -> "honda", "doc_count" -> 3, "color" -> Map("doc_count_error_upper_bound" -> 0, "sum_other_doc_count" -> 0, "buckets" -> List(Map("key" -> "black", "doc_count" -> 2), Map("key" -> "red", "doc_count" -> 1)))))))
+      val aggregationsQueryFuture = restClient.bucketNestedAggregation(index, tpe, aggregationsQuery)
       aggregationsQueryFuture.futureValue should be(expected)
     }
 


### PR DESCRIPTION
Hi,

We need to do aggregations with [nesting buckets inside other buckets](https://www.elastic.co/guide/en/elasticsearch/guide/current/_buckets_inside_buckets.html).

This is a breaking change as the object returned now a `Bucket` instead of a `BucketAggregationResultBody`
We return a map instead of a well defined case class because the buckets name can be specified in the query.

Please, tell me what you think.

Cheers,
Arnaud.
