### PR TITLE
Add geo distance filter 

### DIFF
--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/MappingDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/MappingDsl.scala
@@ -69,6 +69,10 @@ trait MappingDsl extends DslCommons {
     val rep = "binary"
   }
 
+  // Geo point -  https://www.elastic.co/guide/en/elasticsearch/guide/current/geopoints.html
+  case object GeoPointType extends FieldType {
+    val rep = "geo_point"
+  }
 
   sealed trait IndexType {
     val rep: String

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
@@ -249,4 +249,26 @@ trait QueryDsl extends DslCommons {
     val _matchAll = "match_all"
     override def toJson: Map[String, Any] = Map(_matchAll -> Map())
   }
+
+  case class GeoLocation(lat: Double, lon: Double) extends Query {
+    val _lat = "lat"
+    val _lon = "lon"
+
+    override def toJson: Map[String, Any] = Map(
+      _lat -> lat,
+      _lon -> lon
+    )
+  }
+
+  case class GeoDistanceFilter(distance: String, field: String, location: GeoLocation) extends Filter {
+    val _geoDistance = "geo_distance"
+    val _distance = "distance"
+
+    override def toJson: Map[String, Any] = Map(
+      _geoDistance -> Map(
+        _distance -> distance,
+        field -> location.toJson
+      )
+    )
+  }
 }

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -484,6 +484,26 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       val regexQueryFuture2 = restClient.query(index, tpe, QueryRoot(filteredQuery2))
       regexQueryFuture2.futureValue.sourceAsMap.toSet should be(Set(Map("f1" -> "regexFilter1", "f2" -> 1, "text" -> "text1"),  Map("f1" -> "regexFilter2", "f2" -> 1, "text" -> "text2")))
     }
+
+    "support geo distance filter" in {
+      // https://www.elastic.co/guide/en/elasticsearch/guide/current/geo-distance.html
+      val geoPointMapping = BasicFieldMapping(GeoPointType, None, None)
+      val metadataMapping = Mapping(tpe, IndexMapping(Map("location" -> geoPointMapping), EnabledFieldMapping(true), Some(false)))
+      val mappingFut = restClient.putMapping(index, tpe, metadataMapping)
+      whenReady(mappingFut) { _ => refresh() }
+
+      val locationDoc1 = Document("locationDoc1", Map("category" -> "categoryName", "location" -> "40.715, -74.011"))
+      val locationDoc2 = Document("locationDoc2", Map("category" -> "categoryName", "location" -> "1, 1"))
+      val locDocsFuture = restClient.bulkIndex(index, tpe, Seq(locationDoc1, locationDoc2))
+      whenReady(locDocsFuture) { _ => refresh() }
+
+     val geoQuery =  MultiTermFilteredQuery(
+        query = MatchQuery("category", "categoryName"),
+        filter = GeoDistanceFilter(s"1km", "location", GeoLocation(40.715, -74.011))
+      )
+      val geoQueryFuture = restClient.query(index, tpe, QueryRoot(geoQuery))
+      geoQueryFuture.futureValue.sourceAsMap.toSet should be(Set(Map("category" -> "categoryName", "location" -> "40.715, -74.011")))
+    }
   }
 }
 


### PR DESCRIPTION
Hi,

I've added a new filter called `geo_distance`.
The `geo_distance` filter draws a circle around the specified location and finds all documents that have a geo-point within that circle. [More information](https://www.elastic.co/guide/en/elasticsearch/guide/current/geo-distance.html).
- create new GeoPointType
- add geo distance filter

Cheers,
Arnaud.
