### PR TITLE
Refactoring to handle sorting by distance

### DIFF
--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/MappingDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/MappingDsl.scala
@@ -69,6 +69,10 @@ trait MappingDsl extends DslCommons {
     val rep = "binary"
   }
 
+  // Geo point -  https://www.elastic.co/guide/en/elasticsearch/guide/current/geopoints.html
+  case object GeoPointType extends FieldType {
+    val rep = "geo_point"
+  }
 
   sealed trait IndexType {
     val rep: String

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
@@ -18,7 +18,7 @@
  */
 package com.sumologic.elasticsearch.restlastic.dsl
 
-trait QueryDsl extends DslCommons {
+trait QueryDsl extends DslCommons with SortDsl {
 
   trait Query extends EsOperation
 
@@ -27,11 +27,11 @@ trait QueryDsl extends DslCommons {
   trait Filter extends EsOperation
 
   case class QueryRoot(query: Query,
-                       fromOpt: Option[Int] = None,
-                       sizeOpt: Option[Int] = None,
-                       sortOpt: Option[Seq[(String, String)]] = None,
-                       timeout: Option[Int] = None,
-                       sourceFilter: Option[Seq[String]] = None)
+                       fromOpt: Option[Int],
+                       sizeOpt: Option[Int],
+                       sort: Seq[Sort],
+                       timeout: Option[Int],
+                       sourceFilter: Option[Seq[String]])
     extends RootObject {
 
     val _query = "query"
@@ -47,9 +47,23 @@ trait QueryDsl extends DslCommons {
         fromOpt.map(_from -> _) ++
         sizeOpt.map(_size -> _) ++
         timeout.map(t => _timeout -> s"${t}ms") ++
-        sortOpt.map(_sort -> _.map {
-          case (field, order) => field -> Map(_order -> order) }) ++
+        sort.map(_sort -> _.toJson) ++
         sourceFilter.map(_source -> _)
+    }
+  }
+
+  object QueryRoot {
+
+    def apply(query: Query,
+              fromOpt: Option[Int] = None,
+              sizeOpt: Option[Int] = None,
+              sortOpt: Option[Seq[(String, String)]] = None,
+              timeout: Option[Int] = None,
+              sourceFilter: Option[Seq[String]] = None): QueryRoot = {
+      val sorts = sortOpt
+        .map(_.foldLeft(Seq.empty[Sort])((sorts, value) => sorts :+ SimpleSort(value._1, SortOrder.fromString(value._2))))
+        .getOrElse(Nil)
+      new QueryRoot(query, fromOpt, sizeOpt, sorts, timeout, sourceFilter)
     }
   }
 
@@ -248,5 +262,15 @@ trait QueryDsl extends DslCommons {
   case object MatchAll extends Query {
     val _matchAll = "match_all"
     override def toJson: Map[String, Any] = Map(_matchAll -> Map())
+  }
+
+  case class GeoLocation(lat: Double, lon: Double) extends Query {
+    val _lat = "lat"
+    val _lon = "lon"
+
+    override def toJson: Map[String, Any] = Map(
+      _lat -> lat,
+      _lon -> lon
+    )
   }
 }

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/SortDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/SortDsl.scala
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.sumologic.elasticsearch.restlastic.dsl
+
+import com.sumologic.elasticsearch.restlastic.dsl.Dsl.GeoLocation
+
+//object SortDsl extends SortDsl
+trait SortDsl extends DslCommons {
+
+  trait Sort extends EsOperation
+
+  case class SimpleSort(field: String, order: SortOrder) extends Sort {
+    val _order = "order"
+
+    override def toJson: Map[String, Any] = Map(field ->
+      Map(_order -> order.value)
+    )
+  }
+
+  case class GeoDistanceSort(field: String, location: GeoLocation, order: SortOrder, unit: String, distanceType: String) extends Sort {
+    val _geoDistance = "_geo_distance"
+    val _order = "order"
+    val _unit = "unit"
+    val _distanceType = "distance_type"
+
+    override def toJson: Map[String, Any] = Map(
+      _geoDistance -> Map(
+        field -> location.toJson,
+        _order -> order.value,
+        _unit -> unit,
+        _distanceType -> distanceType)
+    )
+  }
+
+  sealed trait SortOrder {
+    def value: String
+  }
+
+  object SortOrder {
+    def fromString(order: String): SortOrder = order match {
+      case "asc" => AscSortOrder
+      case "desc" => DescSortOrder
+    }
+  }
+
+  case object AscSortOrder extends SortOrder {
+    lazy val value: String = "asc"
+
+    override def toString: String = value
+  }
+
+  case object DescSortOrder extends SortOrder {
+    lazy val value: String = "desc"
+
+    override def toString: String = value
+  }
+
+}

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -484,6 +484,66 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       val regexQueryFuture2 = restClient.query(index, tpe, QueryRoot(filteredQuery2))
       regexQueryFuture2.futureValue.sourceAsMap.toSet should be(Set(Map("f1" -> "regexFilter1", "f2" -> 1, "text" -> "text1"),  Map("f1" -> "regexFilter2", "f2" -> 1, "text" -> "text2")))
     }
+
+    "support simple sorting" in {
+      // https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-sort.html
+      val sortDoc1 = Document("simpleSortDoc1", Map("f1" -> "simpleSort", "cat" -> "aaa"))
+      val sortDoc2 = Document("simpleSortDoc2", Map("f1" -> "simpleSort", "cat" -> "aab"))
+      val sortFuture = restClient.bulkIndex(index, tpe, Seq(sortDoc1, sortDoc2))
+      whenReady(sortFuture) { ok => refresh() }
+      val sortQueryAscFuture = restClient.query(index, tpe, new QueryRoot(
+        query = MatchQuery("f1", "simpleSort"),
+        fromOpt = None,
+        sizeOpt = None,
+        sort = Seq(SimpleSort("cat", AscSortOrder)),
+        timeout = None,
+        sourceFilter = None)
+      )
+      sortQueryAscFuture.futureValue.sourceAsMap should be(Seq(Map("f1" -> "simpleSort", "cat" -> "aaa"), Map("f1" -> "simpleSort", "cat" -> "aab")))
+
+      val sortQueryDescFuture = restClient.query(index, tpe, new QueryRoot(
+        query = MatchQuery("f1", "simpleSort"),
+        fromOpt = None,
+        sizeOpt = None,
+        sort = Seq(SimpleSort("cat", DescSortOrder)),
+        timeout = None,
+        sourceFilter = None)
+      )
+      sortQueryDescFuture.futureValue.sourceAsMap should be(Seq(Map("f1" -> "simpleSort", "cat" -> "aab"), Map("f1" -> "simpleSort", "cat" -> "aaa")))
+    }
+
+    "support sorting by Distance" in {
+      // https://www.elastic.co/guide/en/elasticsearch/guide/current/sorting-by-distance.html
+      val geoPointMapping = BasicFieldMapping(GeoPointType, None, None)
+      val metadataMapping = Mapping(tpe, IndexMapping(Map("location" -> geoPointMapping), EnabledFieldMapping(true), Some(false)))
+      val mappingFut = restClient.putMapping(index, tpe, metadataMapping)
+      whenReady(mappingFut) { _ => refresh() }
+
+      val locationDoc1 = Document("locationDoc1", Map("f1" -> "locationDoc", "location" -> "40.715, -74.011"))
+      val locationDoc2 = Document("locationDoc2", Map("f1" -> "locationDoc", "location" -> "1, 1"))
+      val locDocsFuture = restClient.bulkIndex(index, tpe, Seq(locationDoc1, locationDoc2))
+      whenReady(locDocsFuture) { _ => refresh() }
+
+      val sortQueryAscFuture = restClient.query(index, tpe, new QueryRoot(
+        MatchQuery("f1", "locationDoc"),
+        fromOpt = None,
+        sizeOpt = None,
+        sort = Seq(GeoDistanceSort("location", GeoLocation(40.715, -74.011), AscSortOrder, "km", "plane")),
+        timeout = None,
+        sourceFilter = None)
+      )
+      sortQueryAscFuture.futureValue.sourceAsMap should be(Seq(Map("f1" -> "locationDoc", "location" -> "40.715, -74.011"), Map("f1" -> "locationDoc", "location" -> "1, 1")))
+
+      val sortQueryDescFuture = restClient.query(index, tpe, new QueryRoot(
+        MatchQuery("f1", "locationDoc"),
+        fromOpt = None,
+        sizeOpt = None,
+        sort = Seq(GeoDistanceSort("location", GeoLocation(40.715, -74.011), DescSortOrder, "km", "plane")),
+        timeout = None,
+        sourceFilter = None)
+      )
+      sortQueryDescFuture.futureValue.sourceAsMap should be(Seq(Map("f1" -> "locationDoc", "location" ->  "1, 1"), Map("f1" -> "locationDoc", "location" -> "40.715, -74.011")))
+    }
   }
 }
 


### PR DESCRIPTION
Hi,

We need to sort the result by [distance](https://www.elastic.co/guide/en/elasticsearch/guide/current/sorting-by-distance.html).
- update QueryRoot to get more complex sorting than a string tuple
- QueryDsl extends now SortDsl
- SortDsl has `SimpleSort`,  `GeoDistanceSort` and `asc`, `desc` order
- add GeoPointType

Please, tell me what you think.

Cheers,
Arnaud.
