### PR TITLE
AwsRequestSigner and refresh tokens

### DIFF
--- a/elasticsearch-aws/src/main/scala/com/sumologic/elasticsearch/util/AwsRequestSigner.scala
+++ b/elasticsearch-aws/src/main/scala/com/sumologic/elasticsearch/util/AwsRequestSigner.scala
@@ -176,3 +176,25 @@ class AwsRequestSigner(awsCredentials: AWSCredentials, region: String, service: 
 
   private def hexOf(buf: Array[Byte]) = buf.map("%02X" format _).mkString.toLowerCase
 }
+
+/** Factory for [[com.sumologic.elasticsearch.util.AwsRequestSigner]] instances. */
+object AwsRequestSigner {
+
+  /**
+   * Some credentials needs to be refreshed like the credentials provided by [[com.amazonaws.auth.InstanceProfileCredentialsProvider]].
+   *
+   *
+   *{{{
+   *private val aWSCredentialsProvider =  new DefaultAWSCredentialsProviderChain()
+   *val awsCredentials: () => AWSCredentials = aWSCredentialsProvider.getCredentials _
+   *}}}
+   * @constructor create a new AwsRequestSigner with a function that returns the AWSCredentials.
+   * @param awsCredentialsFunction a function that return the AWSCredentials.
+   * @param region the location of the hosted AWS service. (eg. "us-east-1")
+   * @param service the service to connect to (eg. "es" for elasticsearch)
+   * @return a new AwsRequestSigner instance
+   */
+  def apply(awsCredentialsFunction:() => AWSCredentials, region: String, service: String): AwsRequestSigner = {
+      new AwsRequestSigner(awsCredentialsFunction(), region, service)
+  }
+}

--- a/elasticsearch-aws/src/main/scala/com/sumologic/elasticsearch/util/AwsRequestSigner.scala
+++ b/elasticsearch-aws/src/main/scala/com/sumologic/elasticsearch/util/AwsRequestSigner.scala
@@ -183,11 +183,13 @@ object AwsRequestSigner {
   /**
    * Some credentials needs to be refreshed like the credentials provided by [[com.amazonaws.auth.InstanceProfileCredentialsProvider]].
    *
+   *==Usage==
    *
-   *{{{
-   *private val aWSCredentialsProvider =  new DefaultAWSCredentialsProviderChain()
-   *val awsCredentials: () => AWSCredentials = aWSCredentialsProvider.getCredentials _
-   *}}}
+   * {{{
+   * private val aWSCredentialsProvider =  new DefaultAWSCredentialsProviderChain()
+   * val awsCredentials: () => AWSCredentials = aWSCredentialsProvider.getCredentials _
+   * val signer = AwsRequestSigner(awsCredentials, "us-east-1", "es")
+   * }}}
    * @constructor create a new AwsRequestSigner with a function that returns the AWSCredentials.
    * @param awsCredentialsFunction a function that return the AWSCredentials.
    * @param region the location of the hosted AWS service. (eg. "us-east-1")


### PR DESCRIPTION
Hi,

This PR is linked to the issue #63.

It adds a new `AwsRequestSigner` constructor to handle aws tokens that needs to be refreshed.

An other way is to pass a `AWSCredentialsProvider` instead of the `AWSCredentials` and call `getCredentials()` method in `AwsRequestSigner` class.

What about a merge with the following project https://github.com/ticofab/aws-request-signer ?

What do you think?

Thanks,
Arnaud.
