### PR TITLE
Update AwsRequestSigner to use AWSCredentialsProvider

### DIFF
--- a/elasticsearch-aws/src/main/scala/com/sumologic/elasticsearch/util/AwsRequestSigner.scala
+++ b/elasticsearch-aws/src/main/scala/com/sumologic/elasticsearch/util/AwsRequestSigner.scala
@@ -39,7 +39,7 @@ import spray.http.HttpRequest
  */
 class AwsRequestSigner(awsCredentialsProvider: AWSCredentialsProvider, region: String, service: String) extends RequestSigner {
   val Algorithm = "AWS4-HMAC-SHA256"
-  require(Option(awsCredentialsProvider.getCredentials).isDefined, "awsCredentialsProvider must return non null awsCredentials.")
+  require(awsCredentialsProvider.getCredentials != null, "awsCredentialsProvider must return non null awsCredentials.")
 
   /**
    * Sign AWS requests following the instructions at http://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html


### PR DESCRIPTION
Hi, 

We are using the `EC2ContainerCredentialsProviderWrapper` to loads the credentials from Amazon EC2 Instance Metadata Service. These `AWSCredentials` needs to be refreshed so it's better to use the aws provider and let the provider handling the refresh logic then using directly the `AWSCredentials` class.

This change is backward compatible as we create a `StaticCredentialsProvider` if we pass the `AWSCredentials` on the second constructor.
This PR follow PR #64.

Cheers.
Arnaud.
