### PR TITLE
Add match query boost

### DIFF
--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
@@ -216,15 +216,7 @@ trait QueryDsl extends DslCommons with SortDsl {
     }
   }
 
-  case class MatchQuery(key: String, value: String) extends Query {
-    val _match = "match"
-
-    override def toJson: Map[String, Any] = {
-      Map(_match -> Map(key -> value))
-    }
-  }
-
-  case class MatchQueryWithBoost(key: String, value: String, boost: Double) extends Query {
+  case class MatchQuery(key: String, value: String, boost: Double = 1) extends Query {
     val _match = "match"
     val _query = "query"
     val _boost = "boost"

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
@@ -226,14 +226,13 @@ trait QueryDsl extends DslCommons with SortDsl {
 
   case class MatchQueryWithBoost(key: String, value: String, boost: Double) extends Query {
     val _match = "match"
-    val _content = "content"
     val _query = "query"
     val _boost = "boost"
 
     override def toJson: Map[String, Any] = {
       Map(_match ->
-        Map(_content ->
-          Map(_query -> key,
+        Map(key ->
+          Map(_query -> value,
               _boost -> boost)))
     }
   }

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
@@ -224,6 +224,20 @@ trait QueryDsl extends DslCommons with SortDsl {
     }
   }
 
+  case class MatchQueryWithBoost(key: String, value: String, boost: Double) extends Query {
+    val _match = "match"
+    val _content = "content"
+    val _query = "query"
+    val _boost = "boost"
+
+    override def toJson: Map[String, Any] = {
+      Map(_match ->
+        Map(_content ->
+          Map(_query -> key,
+              _boost -> boost)))
+    }
+  }
+
   case class PhraseQuery(key: String, value: String) extends Query {
     val _matchPhrase = "match_phrase"
 

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -404,12 +404,12 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       }
     }
 
-    "Support MatchQueryWithBoost" in {
+    "Support MatchQuery with boost" in {
       val matchDoc = Document("matchDoc", Map("f1" -> "MatchQueryWithBoost", "f2" -> 5))
       val matchNotInsertionFuture = restClient.index(index, tpe, matchDoc)
       whenReady(matchNotInsertionFuture) { _ => refresh() }
 
-      val matchResultFuture = restClient.query(index, tpe, QueryRoot(MatchQueryWithBoost("f1", "MatchQueryWithBoost", 5)))
+      val matchResultFuture = restClient.query(index, tpe, QueryRoot(MatchQuery("f1", "MatchQueryWithBoost", 5)))
       whenReady(matchResultFuture) { resp =>
         resp.extractSource[DocType].head should be(DocType("MatchQueryWithBoost", 5))
       }

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -404,6 +404,17 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       }
     }
 
+    "Support MatchQueryWithBoost" in {
+      val matchDoc = Document("matchDoc", Map("f1" -> "MatchQueryWithBoost", "f2" -> 5))
+      val matchNotInsertionFuture = restClient.index(index, tpe, matchDoc)
+      whenReady(matchNotInsertionFuture) { _ => refresh() }
+
+      val matchResultFuture = restClient.query(index, tpe, QueryRoot(MatchQueryWithBoost("f1", "MatchQueryWithBoost", 5)))
+      whenReady(matchResultFuture) { resp =>
+        resp.extractSource[DocType].head should be(DocType("MatchQueryWithBoost", 5))
+      }
+    }
+
     "Support PhraseQuery" in {
       val phraseDoc = Document("matchDoc", Map("f1" -> "Phrase Query", "f2" -> 5))
       val phraseNotInsertionFuture = restClient.index(index, tpe, phraseDoc)


### PR DESCRIPTION
Issue #68

It follows this format: 

``` json
"match": {
  "content": {
    "query": "Elasticsearch",
    "boost": 3 
  }
}
```

https://www.elastic.co/guide/en/elasticsearch/guide/current/_boosting_query_clauses.html
