### PR TITLE
Multi match query with options

### DIFF
--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
@@ -313,6 +313,20 @@ trait QueryDsl extends DslCommons with SortDsl {
     )
   }
 
+  case class MultiMatchQueryWithOptions(query: String, options: Map[String, String], fields: String*) extends Query {
+    val _multiMatch = "multi_match"
+    val _query = "query"
+    val _fields = "fields"
+
+    override def toJson: Map[String, Any] = Map(
+      _multiMatch -> (Map(
+        _query -> query,
+        _fields -> fields.toList) ++
+        options
+      )
+    )
+  }
+
   case class GeoLocation(lat: Double, lon: Double) extends Query {
     val _lat = "lat"
     val _lon = "lon"

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -539,14 +539,14 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
 
     "support multi match query with option" in {
       // https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html
-      val multiMatchDoc1 = Document("multiMatchDoc1", Map("f1" -> "multimatch1 test", "f2" -> 1, "text" -> "text1"))
-      val multiMatchDoc2 = Document("multiMatchDoc2", Map("f1" -> "text1", "f2" -> 1, "text" -> "multimatch1"))
+      val multiMatchDoc1 = Document("multiMatchOptionDoc1", Map("f1" -> "multimatch1 test", "f2" -> 1, "text" -> "text1"))
+      val multiMatchDoc2 = Document("multiMatchOptionDoc2", Map("f1" -> "text1", "f2" -> 1, "text" -> "multimatch1"))
       val docsFuture = restClient.bulkIndex(index, tpe, Seq(multiMatchDoc1, multiMatchDoc2))
       whenReady(docsFuture) { _ => refresh() }
 
-      val matchQuery = MultiMatchQueryWithOptions("multimatch1", Map("operator" -> "and"), "f1", "text")
+      val matchQuery = MultiMatchQueryWithOptions("multimatch1 test", Map("operator" -> "and"), "f1", "text")
       val matchQueryFuture = restClient.query(index, tpe, QueryRoot(matchQuery))
-      matchQueryFuture.futureValue.sourceAsMap.toSet should be(Set(Map("f1" -> "text1", "f2" -> 1, "text" -> "multimatch1")))
+      matchQueryFuture.futureValue.sourceAsMap.toSet should be(Set(Map("f1" -> "multimatch1 test", "f2" -> 1, "text" -> "text1")))
     }
 
     "support geo distance filter" in {

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -537,6 +537,18 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       matchQueryFuture.futureValue.sourceAsMap.toSet should be(Set(Map("f1" -> "text1", "f2" -> 1, "text" -> "multimatch1"), Map("f1" -> "multimatch1", "f2" -> 1, "text" -> "text1")))
     }
 
+    "support multi match query with option" in {
+      // https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html
+      val multiMatchDoc1 = Document("multiMatchDoc1", Map("f1" -> "multimatch1 test", "f2" -> 1, "text" -> "text1"))
+      val multiMatchDoc2 = Document("multiMatchDoc2", Map("f1" -> "text1", "f2" -> 1, "text" -> "multimatch1"))
+      val docsFuture = restClient.bulkIndex(index, tpe, Seq(multiMatchDoc1, multiMatchDoc2))
+      whenReady(docsFuture) { _ => refresh() }
+
+      val matchQuery = MultiMatchQueryWithOptions("multimatch1", Map("operator" -> "and"), "f1", "text")
+      val matchQueryFuture = restClient.query(index, tpe, QueryRoot(matchQuery))
+      matchQueryFuture.futureValue.sourceAsMap.toSet should be(Set(Map("f1" -> "text1", "f2" -> 1, "text" -> "multimatch1")))
+    }
+
     "support geo distance filter" in {
       // https://www.elastic.co/guide/en/elasticsearch/guide/current/geo-distance.html
       val geoPointMapping = BasicFieldMapping(GeoPointType, None, None)


### PR DESCRIPTION
Hi,

I wanted to add some options to the `MultiMatchQuery` like `"operator":   "and"`
I didn't want to break the `MultiMatchQuery` class so I created a new one called `MultiMatchQueryWithOptions` which has a new parameter `options: Map[String, String]`

https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html

Tell me what you think!

Thanks.
