### PR TITLE
Add option to specify whether to return rawJsonStr along with RawJsonResponse

### DIFF
--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -75,13 +75,10 @@ class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[
   import RestlasticSearchClient.ReturnTypes._
 
   def ready: Boolean = endpointProvider.ready
-  def query(index: Index, tpe: Type, query: QueryRoot, rawJsonStr: Option[Boolean] = Some(true)): Future[SearchResponse] = {
+  def query(index: Index, tpe: Type, query: QueryRoot, rawJsonStr: Boolean = true): Future[SearchResponse] = {
     implicit val ec = searchExecutionCtx
     runEsCommand(query, s"/${index.name}/${tpe.name}/_search").map { rawJson =>
-      val jsonStr = rawJsonStr match {
-        case Some(true) => rawJson.jsonStr
-        case _ => ""
-      }
+      val jsonStr = if(rawJsonStr) rawJson.jsonStr else ""
       SearchResponse(rawJson.mappedTo[RawSearchResponse], jsonStr)
     }
   }

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -75,10 +75,13 @@ class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[
   import RestlasticSearchClient.ReturnTypes._
 
   def ready: Boolean = endpointProvider.ready
-  def query(index: Index, tpe: Type, query: QueryRoot): Future[SearchResponse] = {
+  def query(index: Index, tpe: Type, query: QueryRoot, rawJsonStr: Option[Boolean] = Some(true)): Future[SearchResponse] = {
     implicit val ec = searchExecutionCtx
     runEsCommand(query, s"/${index.name}/${tpe.name}/_search").map { rawJson =>
-      val jsonStr = if(query.sourceFilter.isDefined) "" else rawJson.jsonStr
+      val jsonStr = rawJsonStr match {
+        case Some(true) => rawJson.jsonStr
+        case _ => ""
+      }
       SearchResponse(rawJson.mappedTo[RawSearchResponse], jsonStr)
     }
   }

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -640,7 +640,7 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
     }
 
     "not return rawJsonStr if not required" in {
-      val resFut = restClient.query(index, tpe, QueryRoot(TermQuery("text", "here")), rawJsonStr = Some(false))
+      val resFut = restClient.query(index, tpe, QueryRoot(TermQuery("text", "here")), rawJsonStr = false)
       resFut.futureValue.jsonStr should be("")
       resFut.futureValue.sourceAsMap.head should be(Map("text" -> "here"))
     }

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -638,6 +638,12 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       )
       sortQueryDescFuture.futureValue.sourceAsMap should be(Seq(Map("f1" -> "distanceSortDoc", "location" ->  "1, 1"), Map("f1" -> "distanceSortDoc", "location" -> "40.715, -74.011")))
     }
+
+    "not return rawJsonStr if not required" in {
+      val resFut = restClient.query(index, tpe, QueryRoot(TermQuery("text", "here")), rawJsonStr = Some(false))
+      resFut.futureValue.jsonStr should be("")
+      resFut.futureValue.sourceAsMap.head should be(Map("text" -> "here"))
+    }
   }
 }
 


### PR DESCRIPTION
This PR implements the design discussed in https://github.com/SumoLogic/elasticsearch-client/issues/66

The PR adds an option to let user specify
- true: return rawJsonStr along with rawJsonResponse 
- false: only return rawJsonResponse (reson we do this is that for large documents, it has certain performance impacts when we retrieve many documents with one query)

rawJsonResponse is always returned for backward compatibility. 
