### PR TITLE
Add field index options and query dsl for highlight

### DIFF
--- a/elasticsearch-akka/src/test/scala/com/sumologic/elasticsearch/akkahelpers/ScanAndScrollSourceTest.scala
+++ b/elasticsearch-akka/src/test/scala/com/sumologic/elasticsearch/akkahelpers/ScanAndScrollSourceTest.scala
@@ -39,7 +39,7 @@ class ScanAndScrollSourceTest extends WordSpec with Matchers with ScalaFutures {
   implicit val materializer = ActorMaterializer()
 
   def searchResponseFromMap(map: Map[String, AnyRef]) = {
-    val raw = RawSearchResponse(Hits(List(ElasticJsonDocument("index", "type", "id", Some(0.1f), decompose(map).asInstanceOf[JObject])), 1))
+    val raw = RawSearchResponse(Hits(List(ElasticJsonDocument("index", "type", "id", Some(0.1f), decompose(map).asInstanceOf[JObject], None)), 1))
     SearchResponse(raw, "{}")
   }
 

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -75,7 +75,7 @@ class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[
   import RestlasticSearchClient.ReturnTypes._
 
   def ready: Boolean = endpointProvider.ready
-  def query(index: Index, tpe: Type, query: QueryRootBase, rawJsonStr: Boolean = true): Future[SearchResponse] = {
+  def query(index: Index, tpe: Type, query: QueryRootLike, rawJsonStr: Boolean = true): Future[SearchResponse] = {
     implicit val ec = searchExecutionCtx
     runEsCommand(query, s"/${index.name}/${tpe.name}/_search").map { rawJson =>
       val jsonStr = if(rawJsonStr) rawJson.jsonStr else ""

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -75,7 +75,7 @@ class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[
   import RestlasticSearchClient.ReturnTypes._
 
   def ready: Boolean = endpointProvider.ready
-  def query(index: Index, tpe: Type, query: QueryRoot, rawJsonStr: Boolean = true): Future[SearchResponse] = {
+  def query(index: Index, tpe: Type, query: QueryRootBase, rawJsonStr: Boolean = true): Future[SearchResponse] = {
     implicit val ec = searchExecutionCtx
     runEsCommand(query, s"/${index.name}/${tpe.name}/_search").map { rawJson =>
       val jsonStr = if(rawJsonStr) rawJson.jsonStr else ""
@@ -259,6 +259,7 @@ object RestlasticSearchClient {
       }
 
       def sourceAsMap: Seq[Map[String, Any]] = rawSearchResponse.sourceAsMap
+      def highlightAsMaps: Seq[Map[String, Any]] = rawSearchResponse.highlightAsMaps
       def length = rawSearchResponse.hits.hits.length
     }
 
@@ -276,6 +277,7 @@ object RestlasticSearchClient {
       }
 
       def sourceAsMap: Seq[Map[String, Any]] = hits.hits.map(_._source.values)
+      def highlightAsMaps: Seq[Map[String, Any]] = hits.hits.flatMap(_.highlight.map(_.values))
     }
 
     case class BucketNested(underlying: BucketNestedMap)
@@ -299,7 +301,8 @@ object RestlasticSearchClient {
                                    _type: String,
                                    _id: String,
                                     _score: Option[Float],
-                                   _source: JObject)
+                                   _source: JObject,
+                                   highlight: Option[JObject] = None)
 
     case class RawJsonResponse(jsonStr: String) {
       private implicit val formats = org.json4s.DefaultFormats

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/DslCommons.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/DslCommons.scala
@@ -32,10 +32,6 @@ trait DslCommons {
     val rep: String
   }
 
-  trait FieldIndexOption {
-    val option: String
-  }
-
   trait HighlighterType {
     val name: String
   }

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/DslCommons.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/DslCommons.scala
@@ -32,10 +32,6 @@ trait DslCommons {
     val rep: String
   }
 
-  trait HighlighterType {
-    val name: String
-  }
-
   object EsOperation {
     implicit val formats = org.json4s.DefaultFormats
     def compactJson(map: Map[String, Any]) = compact(render(decompose(map)))

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/DslCommons.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/DslCommons.scala
@@ -32,6 +32,14 @@ trait DslCommons {
     val rep: String
   }
 
+  trait FieldIndexOption {
+    val option: String
+  }
+
+  trait HighlighterType {
+    val name: String
+  }
+
   object EsOperation {
     implicit val formats = org.json4s.DefaultFormats
     def compactJson(map: Map[String, Any]) = compact(render(decompose(map)))

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/MappingDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/MappingDsl.scala
@@ -20,6 +20,10 @@ package com.sumologic.elasticsearch.restlastic.dsl
 
 trait MappingDsl extends DslCommons {
 
+  sealed trait IndexOption {
+    val option: String
+  }
+
   // String datatype - https://www.elastic.co/guide/en/elasticsearch/reference/current/string.html
   case object StringType extends FieldType {
     val rep = "string"
@@ -93,19 +97,22 @@ trait MappingDsl extends DslCommons {
     }
   }
 
-  case object DocsIndexOption extends FieldIndexOption {
+  // Supported in elasticsearch v2.4
+  case object DocsIndexOption extends IndexOption {
     val option = "docs"
   }
 
-  case object FreqsIndexOption extends FieldIndexOption {
+  // Supported in elasticsearch v2.4
+  case object FreqsIndexOption extends IndexOption {
     val option = "freqs"
   }
 
-  case object PositionsIndexOption extends FieldIndexOption {
+  // Supported in elasticsearch v2.4
+  case object PositionsIndexOption extends IndexOption {
     val option = "positions"
   }
 
-  case object OffsetsIndexOption extends FieldIndexOption {
+  case object OffsetsIndexOption extends IndexOption {
     val option = "offsets"
   }
 
@@ -139,7 +146,7 @@ trait MappingDsl extends DslCommons {
 
   case class BasicFieldMapping(tpe: FieldType, index: Option[IndexType], analyzer: Option[Name],
                                ignoreAbove: Option[Int] = None, search_analyzer: Option[Name]= None,
-                               fieldIndexOption: Option[FieldIndexOption] = None)
+                               indexOption: Option[IndexOption] = None)
     extends FieldMapping {
 
     override def toJson: Map[String, Any] = Map(
@@ -147,7 +154,7 @@ trait MappingDsl extends DslCommons {
       index.map(_index -> _.rep) ++
       analyzer.map(_analyzer -> _.name) ++
       search_analyzer.map(_searchAnalyzer -> _.name) ++
-      fieldIndexOption.map(_fieldIndexOpions -> _.option)
+      indexOption.map(_fieldIndexOpions -> _.option)
       ignoreAbove.map(_ignoreAbove -> _).toList.toMap
   }
 

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/MappingDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/MappingDsl.scala
@@ -93,6 +93,22 @@ trait MappingDsl extends DslCommons {
     }
   }
 
+  case object DocsIndexOption extends FieldIndexOption {
+    val option = "docs"
+  }
+
+  case object FreqsIndexOption extends FieldIndexOption {
+    val option = "freqs"
+  }
+
+  case object PositionsIndexOption extends FieldIndexOption {
+    val option = "positions"
+  }
+
+  case object OffsetsIndexOption extends FieldIndexOption {
+    val option = "offsets"
+  }
+
   case class Mapping(tpe: Type, mapping: IndexMapping) extends RootObject {
     override def toJson: Map[String, Any] = Map(tpe.name -> mapping.toJson)
   }
@@ -119,9 +135,11 @@ trait MappingDsl extends DslCommons {
   val _analyzer = "analyzer"
   val _searchAnalyzer = "search_analyzer"
   val _ignoreAbove = "ignore_above"
+  val _fieldIndexOpions = "index_options"
 
   case class BasicFieldMapping(tpe: FieldType, index: Option[IndexType], analyzer: Option[Name],
-                               ignoreAbove: Option[Int] = None, search_analyzer: Option[Name]= None)
+                               ignoreAbove: Option[Int] = None, search_analyzer: Option[Name]= None,
+                               fieldIndexOption: Option[FieldIndexOption] = None)
     extends FieldMapping {
 
     override def toJson: Map[String, Any] = Map(
@@ -129,6 +147,7 @@ trait MappingDsl extends DslCommons {
       index.map(_index -> _.rep) ++
       analyzer.map(_analyzer -> _.name) ++
       search_analyzer.map(_searchAnalyzer -> _.name) ++
+      fieldIndexOption.map(_fieldIndexOpions -> _.option)
       ignoreAbove.map(_ignoreAbove -> _).toList.toMap
   }
 

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
@@ -371,11 +371,11 @@ trait QueryDsl extends DslCommons with SortDsl {
     )
   }
 
-  case class HighlightRoot(queryRoot: QueryRoot, Highlight: Highlight)
+  case class HighlightRoot(queryRoot: QueryRoot, highlight: Highlight)
     extends QueryRootBase {
 
     override def toJson: Map[String, Any] = {
-      queryRoot.toJson ++ Highlight.toJson
+      queryRoot.toJson ++ highlight.toJson
     }
   }
 
@@ -398,7 +398,7 @@ trait QueryDsl extends DslCommons with SortDsl {
     )
   }
 
-  case class HighlightField(field: String, Highlighter_type: Option[HighlighterType] = None, fragment_size: Option[Int] = None,
+  case class HighlightField(field: String, highlighter_type: Option[HighlighterType] = None, fragment_size: Option[Int] = None,
                             number_of_fragments: Option[Int] = None, no_match_size: Option[Int] = None, matched_fields: Seq[String] = Seq())
     extends EsOperation {
     val _type = "type"
@@ -410,7 +410,7 @@ trait QueryDsl extends DslCommons with SortDsl {
     override def toJson: Map[String, Any] = Map(
       field -> {
         Map[String, Any]() ++
-          Highlighter_type.map(_type -> _.name) ++
+          highlighter_type.map(_type -> _.name) ++
           fragment_size.map(_fragment_size -> _) ++
           number_of_fragments.map(_number_of_fragments -> _) ++
           no_match_size.map(_no_match_size -> _) ++

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
@@ -20,13 +20,17 @@ package com.sumologic.elasticsearch.restlastic.dsl
 
 trait QueryDsl extends DslCommons with SortDsl {
 
-  trait Query extends EsOperation
-
   sealed trait BoolQuery extends EsOperation
+
+  sealed trait HighlighterType {
+    val name: String
+  }
+
+  trait Query extends EsOperation
 
   trait Filter extends EsOperation
 
-  trait QueryRootBase extends RootObject
+  trait QueryRootLike extends RootObject
 
   case class QueryRoot(query: Query,
                        fromOpt: Option[Int],
@@ -34,7 +38,7 @@ trait QueryDsl extends DslCommons with SortDsl {
                        sort: Seq[Sort],
                        timeout: Option[Int],
                        sourceFilter: Option[Seq[String]])
-    extends QueryRootBase {
+    extends QueryRootLike {
 
     val _query = "query"
     val _size = "size"
@@ -372,7 +376,7 @@ trait QueryDsl extends DslCommons with SortDsl {
   }
 
   case class HighlightRoot(queryRoot: QueryRoot, highlight: Highlight)
-    extends QueryRootBase {
+    extends QueryRootLike {
 
     override def toJson: Map[String, Any] = {
       queryRoot.toJson ++ highlight.toJson

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
@@ -26,13 +26,15 @@ trait QueryDsl extends DslCommons with SortDsl {
 
   trait Filter extends EsOperation
 
+  trait QueryRootBase extends RootObject
+
   case class QueryRoot(query: Query,
                        fromOpt: Option[Int],
                        sizeOpt: Option[Int],
                        sort: Seq[Sort],
                        timeout: Option[Int],
                        sourceFilter: Option[Seq[String]])
-    extends RootObject {
+    extends QueryRootBase {
 
     val _query = "query"
     val _size = "size"
@@ -367,5 +369,65 @@ trait QueryDsl extends DslCommons with SortDsl {
     override def toJson: Map[String, Any] = Map(
       _dis_max -> innerMap
     )
+  }
+
+  case class HighlightRoot(queryRoot: QueryRoot, Highlight: Highlight)
+    extends QueryRootBase {
+
+    override def toJson: Map[String, Any] = {
+      queryRoot.toJson ++ Highlight.toJson
+    }
+  }
+
+  case class Highlight(fields: Seq[HighlightField], preTags: Seq[String] = Seq(), postTags: Seq[String] = Seq())
+    extends EsOperation {
+
+    val _pre_tags = "pre_tags"
+    val _post_tags = "post_tags"
+    val _fields = "fields"
+    val _highlight = "highlight"
+
+    val pre_tags = if (preTags.isEmpty) Map[String, Any]() else Map(_pre_tags -> preTags)
+    val post_tags = if (postTags.isEmpty) Map[String, Any]() else Map(_post_tags -> postTags)
+
+    override def toJson: Map[String, Any] = Map(
+      _highlight -> {
+        Map( _fields -> fields.foldLeft(Map[String, Any]())((l, r) => l ++ r.toJson)) ++
+          pre_tags ++ post_tags
+      }
+    )
+  }
+
+  case class HighlightField(field: String, Highlighter_type: Option[HighlighterType] = None, fragment_size: Option[Int] = None,
+                            number_of_fragments: Option[Int] = None, no_match_size: Option[Int] = None, matched_fields: Seq[String] = Seq())
+    extends EsOperation {
+    val _type = "type"
+    val _fragment_size = "fragment_size"
+    val _number_of_fragments = "number_of_fragments"
+    val _no_match_size = "no_match_size"
+    val _matched_fields = "matched_fields"
+
+    override def toJson: Map[String, Any] = Map(
+      field -> {
+        Map[String, Any]() ++
+          Highlighter_type.map(_type -> _.name) ++
+          fragment_size.map(_fragment_size -> _) ++
+          number_of_fragments.map(_number_of_fragments -> _) ++
+          no_match_size.map(_no_match_size -> _) ++
+          matched_fields.map(_matched_fields -> _)
+      }
+    )
+  }
+
+  case object PlainHighlighter extends HighlighterType {
+    val name = "plain"
+  }
+
+  case object PostingsHighlighter extends HighlighterType {
+    val name = "postings"
+  }
+
+  case object FastVectorHighlighter extends HighlighterType {
+    val name = "fvh"
   }
 }

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
@@ -392,7 +392,7 @@ trait QueryDsl extends DslCommons with SortDsl {
 
     override def toJson: Map[String, Any] = Map(
       _highlight -> {
-        Map( _fields -> fields.foldLeft(Map[String, Any]())((l, r) => l ++ r.toJson)) ++
+        Map( _fields -> fields.map(_.toJson).reduce(_ ++ _)) ++
           pre_tags ++ post_tags
       }
     )

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -88,13 +88,13 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
 
     "Be able to setup document mapping with field index options" in {
       val basicFieldDocsMapping = BasicFieldMapping(StringType, None, Some(analyzerName), None,
-        Some(analyzerName), fieldIndexOption = Some(DocsIndexOption))
+        Some(analyzerName), indexOption = Some(DocsIndexOption))
       val basicFieldFreqsMapping = BasicFieldMapping(StringType, None, Some(analyzerName), None,
-        Some(analyzerName), fieldIndexOption = Some(FreqsIndexOption))
+        Some(analyzerName), indexOption = Some(FreqsIndexOption))
       val basicFieldPositionsMapping = BasicFieldMapping(StringType, None, Some(analyzerName), None,
-        Some(analyzerName), fieldIndexOption = Some(PositionsIndexOption))
+        Some(analyzerName),  indexOption = Some(PositionsIndexOption))
       val basicFieldOffsetsMapping = BasicFieldMapping(StringType, None, Some(analyzerName), None,
-        Some(analyzerName), fieldIndexOption = Some(OffsetsIndexOption))
+        Some(analyzerName), indexOption = Some(OffsetsIndexOption))
 
       val timestampMapping = EnabledFieldMapping(true)
       val metadataMapping = Mapping(tpe, IndexMapping(
@@ -105,6 +105,8 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
 
       val mappingFut = restClient.putMapping(index, tpe, metadataMapping)
       whenReady(mappingFut) { _ => refresh() }
+      val mappingRes = restClient.getMapping(index, tpe)
+      mappingRes.futureValue.jsonStr.toString.contains(""""f2":{"type":"string","index_options":"offsets","analyzer":"keyword_lowercase"}""") should be(true)
     }
 
     "Be able to create an index, index a document, and search it" in {


### PR DESCRIPTION
- Added capability to specify index_options in field mapping 
  https://www.elastic.co/guide/en/elasticsearch/reference/current/index-options.html
- Added query dsl for highlight
  https://www.elastic.co/guide/en/elasticsearch/reference/1.5/search-request-highlighting.html#postings-highlighter
- Added highlight results in SearchResponse
