### PR TITLE
Add option of terminate_after when run a query

### DIFF
--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
@@ -70,11 +70,9 @@ trait QueryDsl extends DslCommons with SortDsl {
       val sorts = sortOpt
         .map(_.foldLeft(Seq.empty[Sort])((sorts, value) => sorts :+ SimpleSort(value._1, SortOrder.fromString(value._2))))
         .getOrElse(Nil)
-      if (terminateAfter.isDefined) {
-        new ExtendedQueryRoot(query, fromOpt, sizeOpt, sorts, timeout, sourceFilter, terminateAfter)
-      } else {
-        new QueryRoot(query, fromOpt, sizeOpt, sorts, timeout, sourceFilter) 
-      }
+      terminateAfter
+        .map(tA => new ExtendedQueryRoot(query, fromOpt, sizeOpt, sorts, timeout, sourceFilter, Some(tA)))
+        .getOrElse(new QueryRoot(query, fromOpt, sizeOpt, sorts, timeout, sourceFilter))
     }
   }
   

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
@@ -72,6 +72,24 @@ trait QueryDsl extends DslCommons with SortDsl {
       new QueryRoot(query, fromOpt, sizeOpt, sorts, timeout, sourceFilter)
     }
   }
+  
+  // This api should be incorporated into QueryRoot in 2.0 when breaking changes are allowed.
+  // Before that, this api can serve to extend QueryRoot with backward compatibility.
+  class ExtendedQueryRoot(override val query: Query,
+                          override val fromOpt: Option[Int] = None,
+                          override val sizeOpt: Option[Int] = None,
+                          override val sort: Seq[Sort] = Seq(),
+                          override val timeout: Option[Int] = None,
+                          override val sourceFilter: Option[Seq[String]] = None,
+                          terminateAfter: Option[Int] = None)
+    extends QueryRoot(query, fromOpt, sizeOpt, sort, timeout, sourceFilter) {
+    
+    val _terminate_after = "terminate_after"
+
+    override def toJson: Map[String, Any] = {
+      super.toJson ++ terminateAfter.map(_terminate_after -> _)
+    }
+  }
 
   case class ConstantScore(filter: Filter) extends SingleField("constant_score", filter) with Filter
 

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
@@ -65,11 +65,16 @@ trait QueryDsl extends DslCommons with SortDsl {
               sizeOpt: Option[Int] = None,
               sortOpt: Option[Seq[(String, String)]] = None,
               timeout: Option[Int] = None,
-              sourceFilter: Option[Seq[String]] = None): QueryRoot = {
+              sourceFilter: Option[Seq[String]] = None,
+              terminateAfter: Option[Int] = None): QueryRoot = {
       val sorts = sortOpt
         .map(_.foldLeft(Seq.empty[Sort])((sorts, value) => sorts :+ SimpleSort(value._1, SortOrder.fromString(value._2))))
         .getOrElse(Nil)
-      new QueryRoot(query, fromOpt, sizeOpt, sorts, timeout, sourceFilter)
+      if (terminateAfter.isDefined) {
+        new ExtendedQueryRoot(query, fromOpt, sizeOpt, sorts, timeout, sourceFilter, terminateAfter)
+      } else {
+        new QueryRoot(query, fromOpt, sizeOpt, sorts, timeout, sourceFilter) 
+      }
     }
   }
   

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -695,9 +695,10 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       resFut.futureValue.sourceAsMap.head should be(Map("text" -> "here"))
     }
 
-    "support query with highlights" in  {
+    "support query with highlights with extended query root" in  {
       val highlights = Highlight(Seq(HighlightField("text", Some(PostingsHighlighter), None, Some(0)), HighlightField("f1", Some(PlainHighlighter))), Seq(""), Seq(""))
-      val resFut = restClient.query(index, tpe, HighlightRoot(QueryRoot(PrefixQuery("text", "h"), None, None, Seq(), None, Some(Seq("false"))), highlights))
+      val resFut = restClient.query(index, tpe, HighlightRoot(new ExtendedQueryRoot(
+        PrefixQuery("text", "h"), None, None, Seq(), None, Some(Seq("false")), terminateAfter = Some(10)), highlights))
       resFut.futureValue.rawSearchResponse.highlightAsMaps.head should be(Map("text" -> List("here")))
     }
   }

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -697,8 +697,8 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
 
     "support query with highlights with extended query root" in  {
       val highlights = Highlight(Seq(HighlightField("text", Some(PostingsHighlighter), None, Some(0)), HighlightField("f1", Some(PlainHighlighter))), Seq(""), Seq(""))
-      val resFut = restClient.query(index, tpe, HighlightRoot(new ExtendedQueryRoot(
-        PrefixQuery("text", "h"), None, None, Seq(), None, Some(Seq("false")), terminateAfter = Some(10)), highlights))
+      val resFut = restClient.query(index, tpe, HighlightRoot(QueryRoot(
+        PrefixQuery("text", "h"), None, None, None, None, Some(Seq("false")), terminateAfter = Some(10)), highlights))
       resFut.futureValue.rawSearchResponse.highlightAsMaps.head should be(Map("text" -> List("here")))
     }
   }


### PR DESCRIPTION
It turns out terminate_after can have huge impact on latency when the document counts are large. 

In order to support terminate_after and maintain backward compatibility, I have to create an ExtendedQueryRoot that inherits QueryRoot. This api can serve to extend any further enhancements to QueryRoot before 2.0. 

This api should be incorporated into QueryRoot in 2.0 when breaking changes are allowed.
