### PR TITLE
Remove log symlink

### DIFF
--- a/elasticsearch-test/src/test/resources/log4j.properties
+++ b/elasticsearch-test/src/test/resources/log4j.properties
@@ -1,1 +1,0 @@
-../../../../test-util/src/test/resources/log4j.properties


### PR DESCRIPTION
If you just clone master and build in IntelliJ, then this causes an error. The endpoint doesn’t exist.
 log4j.properties -> ../../../../test-util/src/test/resources/log4j.properties
It can be fixed by just deleting the symlink. Fixing this allows unit tests to be run and makes it a friendlier project for a developer to start contributing to.
I understand that there may be a preferable fix such as adding the test-util directory back.