### PR TITLE
Refactor Test to remove interdependencies

### DIFF
--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
@@ -270,7 +270,7 @@ trait QueryDsl extends DslCommons with SortDsl {
 
     override def toJson: Map[String, Any] = {
       Map(_prefix ->
-        Map(key-> prefix)
+        Map(key -> prefix)
       )
     }
   }

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -165,7 +165,7 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       whenReady(resFut) { res =>
         res.jsonStr should include("doc3")
         res.jsonStr should include("doc4")
-        res.jsonStr should not include ("doc5")
+        res.jsonStr should not include("doc5")
       }
     }
 
@@ -180,12 +180,12 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       }
       val fut = restClient.startScrollRequest(index, tpe, QueryRoot(MatchAll, Some(1)))
       val scrollId = whenReady(fut) { resp =>
-        resp.id should not be ('empty)
+        resp.id should not be('empty)
         resp
       }
       whenReady(restClient.scroll(scrollId)) { resp =>
-        resp._2.sourceAsMap should not be ('empty)
-        resp._2.sourceAsMap.head should not be ('empty)
+        resp._2.sourceAsMap should not be('empty)
+        resp._2.sourceAsMap.head should not be('empty)
       }
     }
 
@@ -774,7 +774,7 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       whenReady(mappingFut) { _ => refresh() }
       indexDocs(Seq(Document("doc1", Map("f1" -> "text", "text" -> "here"))))
       val resp = restClient.query(index, tpe, QueryRoot(PrefixQuery("text", "h"))).futureValue
-      resp.sourceAsMap should not be ('empty)
+      resp.sourceAsMap should not be('empty)
       val highlights = Highlight(Seq(HighlightField("text", Some(PostingsHighlighter), None, Some(0)),
         HighlightField("f1", Some(PlainHighlighter))), Seq(""), Seq(""))
       val resFut = restClient.query(index, tpe, HighlightRoot(QueryRoot(

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -1,21 +1,21 @@
 /**
-  * Licensed to the Apache Software Foundation (ASF) under one
-  * or more contributor license agreements.  See the NOTICE file
-  * distributed with this work for additional information
-  * regarding copyright ownership.  The ASF licenses this file
-  * to you under the Apache License, Version 2.0 (the
-  * "License"); you may not use this file except in compliance
-  * with the License.  You may obtain a copy of the License at
-  *
-  * http://www.apache.org/licenses/LICENSE-2.0
-  *
-  * Unless required by applicable law or agreed to in writing,
-  * software distributed under the License is distributed on an
-  * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  * KIND, either express or implied.  See the License for the
-  * specific language governing permissions and limitations
-  * under the License.
-  */
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package com.sumologic.elasticsearch.restlastic
 
 import com.sumologic.elasticsearch.restlastic.RestlasticSearchClient.ReturnTypes._


### PR DESCRIPTION
I'd like to make a second pass to refactor the tests into multiple files because it's getting out of hand, however, I think this is a marked improvement. The PR enables OneInstancePerTest as suggested by @claymccoy to create Elasticsearch tests that are isolated from one-another.

@CCheSumo Please review.

Closes #93.