### PR TITLE
upgrade elasticsearch and repair error handling

### DIFF
--- a/elasticsearch-core/pom.xml
+++ b/elasticsearch-core/pom.xml
@@ -68,23 +68,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.lucene</groupId>
-      <artifactId>lucene-core</artifactId>
-      <version>4.10.4</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>org.apache.lucene</groupId>
-      <artifactId>lucene-analyzers-common</artifactId>
-      <version>4.10.4</version>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.elasticsearch</groupId>
       <artifactId>elasticsearch</artifactId>
-      <version>1.6.2</version>
+      <version>2.4.3</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -223,9 +223,7 @@ class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[
       if (response.status.isFailure) {
         logger.warn(s"Failure response: ${response.entity.asString.take(500)}")
         logger.warn(s"Failing request: ${op.take(5000)}")
-
-        val jsonTree = parse(response.entity.asString)
-        throw jsonTree.extract[ElasticErrorResponse]
+        throw ElasticErrorResponse(response.entity.asString, response.status.intValue)
       }
       RawJsonResponse(response.entity.asString)
     }

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -18,7 +18,7 @@
  */
 package com.sumologic.elasticsearch.restlastic
 
-import com.sumologic.elasticsearch.restlastic.RestlasticSearchClient.ReturnTypes._
+import com.sumologic.elasticsearch.restlastic.RestlasticSearchClient.ReturnTypes.{ElasticErrorResponse, _}
 import spray.http.HttpMethods._
 import com.sumologic.elasticsearch.restlastic.dsl.Dsl._
 import com.sumologic.elasticsearch_test.ElasticsearchIntegrationTest
@@ -210,6 +210,15 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       val future = restClient.runRawEsRequest(op = "", endpoint = "/_stats/indices", GET)
       whenReady(future) { res =>
         res.jsonStr should include(IndexName)
+      }
+    }
+
+    "Return error on failed raw requests" in {
+      val future = restClient.runRawEsRequest(op = "", endpoint = "/does/not/exist", GET)
+      whenReady(future.failed) { e =>
+        e shouldBe a [ElasticErrorResponse]
+        val elasticErrorResponse = e.asInstanceOf[ElasticErrorResponse]
+        elasticErrorResponse.status should be(404)
       }
     }
 

--- a/elasticsearch-test/pom.xml
+++ b/elasticsearch-test/pom.xml
@@ -24,28 +24,17 @@
 
     <!-- ATTN: If you need elasticsearch-test you need to also add these dependencies to your pom directly
          with <scope>test</scope>! -->
-    <dependency>
-      <groupId>org.apache.lucene</groupId>
-      <artifactId>lucene-core</artifactId>
-      <version>4.10.4</version>
-    </dependency>
 
     <dependency>
-      <groupId>org.apache.lucene</groupId>
-      <artifactId>lucene-analyzers-common</artifactId>
-      <version>4.10.4</version>
+      <groupId>org.elasticsearch</groupId>
+      <artifactId>elasticsearch</artifactId>
+      <version>2.4.3</version>
     </dependency>
 
     <dependency>
       <groupId>org.elasticsearch</groupId>
       <artifactId>elasticsearch</artifactId>
-      <version>1.6.2</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.elasticsearch</groupId>
-      <artifactId>elasticsearch</artifactId>
-      <version>1.6.2</version>
+      <version>2.4.3</version>
       <type>test-jar</type>
     </dependency>
 

--- a/elasticsearch-test/src/main/scala/com/sumologic/elasticsearch_test/ElasticsearchIntegrationTest.scala
+++ b/elasticsearch-test/src/main/scala/com/sumologic/elasticsearch_test/ElasticsearchIntegrationTest.scala
@@ -22,7 +22,7 @@ import java.io.File
 
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest
 import org.elasticsearch.client.transport.TransportClient
-import org.elasticsearch.common.settings.ImmutableSettings
+import org.elasticsearch.common.settings.Settings
 import org.elasticsearch.common.transport.{InetSocketTransportAddress, LocalTransportAddress}
 import org.elasticsearch.node.NodeBuilder
 import org.scalatest.{BeforeAndAfterAll, Suite}
@@ -71,10 +71,14 @@ trait ElasticsearchIntegrationTest extends BeforeAndAfterAll {
 
 object ElasticsearchIntegrationTest {
   private val r = new Random()
-  private lazy val esNodeSettings = ImmutableSettings.settingsBuilder().put("path.data", createTempDir("elasticsearch-test")).build()
+  private val workingDir = createTempDir("elasticsearch-test")
+  private lazy val esNodeSettings = Settings.settingsBuilder()
+    .put("path.data", workingDir)
+    .put("path.home", workingDir)
+    .build()
   private lazy val esNode = NodeBuilder.nodeBuilder().local(true).settings(esNodeSettings).node()
-  private lazy val settings = ImmutableSettings.settingsBuilder().put("node.local", "true").build()
-  lazy val client = new TransportClient(settings).addTransportAddress(new LocalTransportAddress("1"))
+  private lazy val settings = Settings.settingsBuilder().put("node.local", "true").build()
+  lazy val client = new TransportClient.Builder().settings(settings).build().addTransportAddress(new LocalTransportAddress("1"))
   lazy val globalEndpoint = {
     val nodeInfos = client.admin().cluster().prepareNodesInfo().clear().setSettings(true).setHttp(true).get()
     val nodeAddress =


### PR DESCRIPTION
Many users are going to be using a newer version of elasticsearch. These commits add a test for elastic search error handling, then upgrade elasticsearch where the test fails. The final commit repairs the test in a way that should work with any elasticsearch version, though it changes the value of ElasticErrorResponse.error.
It looks like upgrading elasticsearch causes a lot of tests to fail, but my intention isn't to upgrade elasticsearch. Though I am using this library in a service with the newer version and I would like to see that. I'm just trying to demonstrate a problem with error handling using newer versions and a potential fix.