### PR TITLE
Error handling without es update

### DIFF
--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -223,9 +223,7 @@ class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[
       if (response.status.isFailure) {
         logger.warn(s"Failure response: ${response.entity.asString.take(500)}")
         logger.warn(s"Failing request: ${op.take(5000)}")
-
-        val jsonTree = parse(response.entity.asString)
-        throw jsonTree.extract[ElasticErrorResponse]
+        throw ElasticErrorResponse(response.entity.asString, response.status.intValue)
       }
       RawJsonResponse(response.entity.asString)
     }

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -18,7 +18,7 @@
  */
 package com.sumologic.elasticsearch.restlastic
 
-import com.sumologic.elasticsearch.restlastic.RestlasticSearchClient.ReturnTypes._
+import com.sumologic.elasticsearch.restlastic.RestlasticSearchClient.ReturnTypes.{ElasticErrorResponse, _}
 import spray.http.HttpMethods._
 import com.sumologic.elasticsearch.restlastic.dsl.Dsl._
 import com.sumologic.elasticsearch_test.ElasticsearchIntegrationTest
@@ -210,6 +210,15 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       val future = restClient.runRawEsRequest(op = "", endpoint = "/_stats/indices", GET)
       whenReady(future) { res =>
         res.jsonStr should include(IndexName)
+      }
+    }
+
+    "Return error on failed raw requests" in {
+      val future = restClient.runRawEsRequest(op = "", endpoint = "/does/not/exist", GET)
+      whenReady(future.failed) { e =>
+        e shouldBe a [ElasticErrorResponse]
+        val elasticErrorResponse = e.asInstanceOf[ElasticErrorResponse]
+        elasticErrorResponse.status should be(404)
       }
     }
 


### PR DESCRIPTION
This is similar to #96, but without the ES update. The new error handling will work with multiple versions of ES. This is handy since users of this library are probably using a newer version of ES. It would be nice if this could go in before the next release.