### PR TITLE
Aws request signer does not set port in Host header correctly

### DIFF
--- a/elasticsearch-aws/src/main/scala/com/sumologic/elasticsearch/util/AwsRequestSigner.scala
+++ b/elasticsearch-aws/src/main/scala/com/sumologic/elasticsearch/util/AwsRequestSigner.scala
@@ -87,7 +87,7 @@ class AwsRequestSigner(awsCredentialsProvider: AWSCredentialsProvider, region: S
     val hostHeader = if (httpRequest.headers.exists(_.name.toLowerCase == "host")) {
       List()
     } else {
-      val hostHeader = Host(httpRequest.uri.authority.host.address)
+      val hostHeader = Host(httpRequest.uri.authority.host.address, httpRequest.uri.authority.port)
       List(hostHeader)
     }
     httpRequest.withHeaders(dateHeader ++ hostHeader ++ httpRequest.headers)


### PR DESCRIPTION
The aws request signer omits the port component of the HttpRequest if it has been supplied and the Host header in the HttpRequest is missing. Without this specified it means you cannot utilise elasticsearch running on AWS under a port other than 80/443, for example if you have a proxy -> aws es, where the proxy operates on a non-80/443 port.