### PR TITLE
Moved hard-coded ask timeout to implicit parameter.

### DIFF
--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -65,10 +65,9 @@ trait RequestSigner {
 class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[RequestSigner] = None,
                              indexExecutionCtx: ExecutionContext = ExecutionContext.Implicits.global,
                              searchExecutionCtx: ExecutionContext = ExecutionContext.Implicits.global)
-                            (implicit val system: ActorSystem = ActorSystem())
+                            (implicit val system: ActorSystem = ActorSystem(), val timeout: Timeout = Timeout(30.seconds))
   extends ScrollClient {
 
-  implicit val timeout: Timeout = Timeout(30.seconds)
   private implicit val formats = org.json4s.DefaultFormats
   private val logger = LoggerFactory.getLogger(RestlasticSearchClient.getClass)
   import Dsl._


### PR DESCRIPTION
Me again (SplashAttacks).  We are running into an issue where multiple large requests (5MB) are timing out  and need to be able to increase the ask timeout to more 30 seconds.  Currently it is hard coded and would like it moved out to implicit with default (like we did with ActorSystem).
Thanks again!