### PR TITLE
2.0 task2 remove highlight default

### DIFF
--- a/elasticsearch-akka/src/test/scala/com/sumologic/elasticsearch/akkahelpers/ScanAndScrollSourceTest.scala
+++ b/elasticsearch-akka/src/test/scala/com/sumologic/elasticsearch/akkahelpers/ScanAndScrollSourceTest.scala
@@ -39,7 +39,7 @@ class ScanAndScrollSourceTest extends WordSpec with Matchers with ScalaFutures {
   implicit val materializer = ActorMaterializer()
 
   def searchResponseFromMap(map: Map[String, AnyRef]) = {
-    val raw = RawSearchResponse(Hits(List(ElasticJsonDocument("index", "type", "id", Some(0.1f), decompose(map).asInstanceOf[JObject], None)), 1))
+    val raw = RawSearchResponse(Hits(List(ElasticJsonDocument("index", "type", "id", Some(0.1f), decompose(map).asInstanceOf[JObject], highlight = None)), 1))
     SearchResponse(raw, "{}")
   }
 

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -312,7 +312,7 @@ object RestlasticSearchClient {
                                    _id: String,
                                     _score: Option[Float],
                                    _source: JObject,
-                                   highlight: Option[JObject] = None)
+                                   highlight: Option[JObject])
 
     case class RawJsonResponse(jsonStr: String) {
       private implicit val formats = org.json4s.DefaultFormats


### PR DESCRIPTION
This will require clients who manually creates a ElasticJosonDocument (most likely for testing) to supply a highlight field or none. Please refer to https://github.com/SumoLogic/elasticsearch-client/issues/77
Here is an example
`val raw = RawSearchResponse(Hits(List(ElasticJsonDocument("index", "type", "id", Some(0.1f), decompose(map).asInstanceOf[JObject], highlight = None)), 1))`