### PR TITLE
Release 2.0.0: Task 4 - remove search_type=scan

### DIFF
--- a/elasticsearch-akka/src/test/scala/com/sumologic/elasticsearch/akkahelpers/ScanAndScrollSourceTest.scala
+++ b/elasticsearch-akka/src/test/scala/com/sumologic/elasticsearch/akkahelpers/ScanAndScrollSourceTest.scala
@@ -69,28 +69,32 @@ class MockScrollClient(results: List[SearchResponse]) extends ScrollClient {
   var started = false
   var resultsQueue = results
   override def startScrollRequest(index: Dsl.Index, tpe: Dsl.Type, query: Dsl.QueryRoot,
-                                  resultWindow: String): Future[ScrollId] = {
+                                  resultWindowOpt: Option[String] = None, fromOpt: Option[Int] = None, sizeOpt: Option[Int] = None): Future[(ScrollId, SearchResponse)] = {
     if (!started) {
       started = true
-      Future.successful(ScrollId(id.toString))
+      processRequest()
     } else {
       Future.failed(new RuntimeException("Scroll already started"))
     }
   }
 
-  override def scroll(scrollId: ScrollId, resultWindow: String): Future[(ScrollId, SearchResponse)] = {
+  override def scroll(scrollId: ScrollId, resultWindowOpt: Option[String] = None): Future[(ScrollId, SearchResponse)] = {
     if (scrollId.id.toInt == id) {
-      id += 1
-      resultsQueue match {
-        case head :: rest =>
-          resultsQueue = rest
-          Future.successful((ScrollId(id.toString), head))
-        case Nil =>
-          Future.successful((ScrollId(id.toString), SearchResponse.empty))
-      }
+      processRequest()
     } else {
       Future.failed(new RuntimeException("Invalid id"))
     }
 
+  }
+
+  private def processRequest(): Future[(ScrollId, SearchResponse)] = {
+    id += 1
+    resultsQueue match {
+      case head :: rest =>
+        resultsQueue = rest
+        Future.successful((ScrollId(id.toString), head))
+      case Nil =>
+        Future.successful((ScrollId(id.toString), SearchResponse.empty))
+    }
   }
 }

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -176,6 +176,8 @@ class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[
     runEsCommand(query, s"/${index.name}/${tpe.name}/_query", DELETE)
   }
 
+  // Scroll requests have optimizations that make them faster when the sort order is _doc.
+  // https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html
   def startScrollRequest(index: Index, tpe: Type, query: QueryRoot, resultWindowOpt: Option[String] = None, fromOpt: Option[Int] = None, sizeOpt: Option[Int] = None): Future[(ScrollId, SearchResponse)] = {
     implicit val ec = searchExecutionCtx
     val params = Map("scroll" -> resultWindowOpt.getOrElse(defaultResultWindow)) ++ fromOpt.map("from" -> _.toString) ++ sizeOpt.map("size" -> _.toString)

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -37,8 +37,9 @@ import org.slf4j.LoggerFactory
 
 trait ScrollClient {
   import Dsl._
-  def startScrollRequest(index: Index, tpe: Type, query: QueryRoot, resultWindow: String = "1m"): Future[ScrollId]
-  def scroll(scrollId: ScrollId, resultWindow: String = "1m"): Future[(ScrollId, SearchResponse)]
+  val defaultResultWindow = "1m"
+  def startScrollRequest(index: Index, tpe: Type, query: QueryRoot, resultWindowOpt: Option[String] = None, fromOpt: Option[Int] = None, sizeOpt: Option[Int] = None): Future[(ScrollId, SearchResponse)]
+  def scroll(scrollId: ScrollId, resultWindowOpt: Option[String] = None): Future[(ScrollId, SearchResponse)]
 }
 
 case class Endpoint(host: String, port: Int)
@@ -175,18 +176,18 @@ class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[
     runEsCommand(query, s"/${index.name}/${tpe.name}/_query", DELETE)
   }
 
-  def startScrollRequest(index: Index, tpe: Type, query: QueryRoot, resultWindow: String = "1m"): Future[ScrollId] = {
+  def startScrollRequest(index: Index, tpe: Type, query: QueryRoot, resultWindowOpt: Option[String] = None, fromOpt: Option[Int] = None, sizeOpt: Option[Int] = None): Future[(ScrollId, SearchResponse)] = {
     implicit val ec = searchExecutionCtx
-    val uriQuery = UriQuery("scroll" -> resultWindow, "search_type" -> "scan")
-    runEsCommand(query, s"/${index.name}/${tpe.name}/_search", query = uriQuery).map { resp =>
-      val parsed = resp.mappedTo[ScrollResponse]
-      ScrollId(parsed._scroll_id)
+    val params = Map("scroll" -> resultWindowOpt.getOrElse(defaultResultWindow)) ++ fromOpt.map("from" -> _.toString) ++ sizeOpt.map("size" -> _.toString)
+    runEsCommand(query, s"/${index.name}/${tpe.name}/_search", query = UriQuery(params)).map { resp =>
+      val sr = resp.mappedTo[SearchResponseWithScrollId]
+      (ScrollId(sr._scroll_id), SearchResponse(RawSearchResponse(sr.hits), resp.jsonStr))
     }
   }
 
-  def scroll(scrollId: ScrollId, resultWindow: String = "1m"): Future[(ScrollId, SearchResponse)] = {
+  def scroll(scrollId: ScrollId, resultWindowOpt: Option[String] = None): Future[(ScrollId, SearchResponse)] = {
     implicit val ec = searchExecutionCtx
-    val uriQuery = UriQuery("scroll_id" -> scrollId.id, "scroll" -> resultWindow)
+    val uriQuery = UriQuery("scroll_id" -> scrollId.id, "scroll" -> resultWindowOpt.getOrElse(defaultResultWindow))
     runEsCommand(NoOp, s"/_search/scroll", query = uriQuery).map { resp =>
       val sr = resp.mappedTo[SearchResponseWithScrollId]
       (ScrollId(sr._scroll_id), SearchResponse(RawSearchResponse(sr.hits), resp.jsonStr))
@@ -337,8 +338,6 @@ object RestlasticSearchClient {
     case class IndexAlreadyExistsException(message: String) extends Exception(message)
 
     case class ElasticErrorResponse(error: String, status: Int) extends Exception(s"ElasticsearchError(status=$status): $error")
-
-    case class ScrollResponse(_scroll_id: String)
 
   }
 

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -177,6 +177,7 @@ class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[
   }
 
   // Scroll requests have optimizations that make them faster when the sort order is _doc.
+  // Put sort by _doc in query as described in the the following document
   // https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html
   def startScrollRequest(index: Index, tpe: Type, query: QueryRoot, resultWindowOpt: Option[String] = None, fromOpt: Option[Int] = None, sizeOpt: Option[Int] = None): Future[(ScrollId, SearchResponse)] = {
     implicit val ec = searchExecutionCtx

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -227,14 +227,14 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       whenReady(Future.sequence(docFutures)) { _ =>
         refresh()
       }
-      val fut = restClient.startScrollRequest(index, tpe, new QueryRoot(MatchAll, Some(1)))
-      val scrollId = whenReady(fut) { resp =>
-        resp.id should not be empty
-        resp
+      val query = new QueryRoot(MatchAll, sortOpt = Some(Seq(SimpleSort("id", AscSortOrder))))
+      val fut = restClient.startScrollRequest(index, tpe, query, fromOpt = Some(1), sizeOpt = Some(5))
+      val scrollId = whenReady(fut) { case (id, data) =>
+        data.sourceAsMap.flatMap(_.values).filter(_ != "ct") should be(List(1, 2, 3, 4, 5))
+        id
       }
-      whenReady(restClient.scroll(scrollId)) { resp =>
-        resp._2.sourceAsMap should not be empty
-        resp._2.sourceAsMap.head should not be empty
+      whenReady(restClient.scroll(scrollId)) { case (id, data) =>
+        data.sourceAsMap.flatMap(_.values).filter(_ != "ct") should be(List(6, 7, 8, 9, 10))
       }
     }
 


### PR DESCRIPTION
Both search_type=scan and search_type=count has been deprecated. Document https://www.elastic.co/guide/en/elasticsearch/reference/2.1/breaking_21_search_changes.html (issue here https://github.com/SumoLogic/elasticsearch-client/issues/100)

I am removing `search_type=scan` from the client. It turned out to be a little tricky due to the inconsistent behavior of `scroll` with/without `search_type=scan` specified

- with`search_type=scan` specified, `scroll` returns the id to start from, no data is returned
- without `search_type=scan` specified (same with `search_type` with anything else but `scan`), `scoll` returns the id to start from, and data

The awkwardness is documented here https://www.elastic.co/guide/en/elasticsearch/reference/1.5/search-request-scroll.html#scroll-scan

In order to remove `scan`, I have to change the return type of startScrollRequest and logics around it. For the same reason, ScanAndScrollSource is updated. 