### PR TITLE
Release 2.0.0: Tast 5 - Unify MultiMatchQueryWithOptions and MultiMatchQuery

### DIFF
--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
@@ -297,19 +297,6 @@ trait QueryDsl extends DslCommons with SortDsl {
     override def value: String = "none"
   }
 
-  case class MultiMatchQuery(query: String, fields: String*) extends Query {
-    val _multiMatch = "multi_match"
-    val _query = "query"
-    val _fields = "fields"
-
-    override def toJson: Map[String, Any] = Map(
-      _multiMatch -> Map(
-        _query -> query,
-        _fields -> fields.toList
-      )
-    )
-  }
-
   case class MultiMatchQueryWithOptions(query: String, options: Map[String, String], fields: String*) extends Query {
     val _multiMatch = "multi_match"
     val _query = "query"

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
@@ -297,7 +297,7 @@ trait QueryDsl extends DslCommons with SortDsl {
     override def value: String = "none"
   }
 
-  case class MultiMatchQueryWithOptions(query: String, options: Map[String, String], fields: String*) extends Query {
+  case class MultiMatchQuery(query: String, options: Map[String, String], fields: String*) extends Query {
     val _multiMatch = "multi_match"
     val _query = "query"
     val _fields = "fields"

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -688,7 +688,7 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       val docsFuture = restClient.bulkIndex(index, tpe, Seq(multiMatchDoc1, multiMatchDoc2))
       whenReady(docsFuture) { _ => refresh() }
 
-      val matchQuery = MultiMatchQueryWithOptions("multimatch1", Map(), "f1", "text")
+      val matchQuery = MultiMatchQuery("multimatch1", Map(), "f1", "text")
       val matchQueryFuture = restClient.query(index, tpe, new QueryRoot(matchQuery))
       matchQueryFuture.futureValue.sourceAsMap.toSet should be(Set(Map("f1" -> "text1", "f2" -> 1, "text" -> "multimatch1"), Map("f1" -> "multimatch1", "f2" -> 1, "text" -> "text1")))
     }
@@ -700,7 +700,7 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       val docsFuture = restClient.bulkIndex(index, tpe, Seq(multiMatchDoc1, multiMatchDoc2))
       whenReady(docsFuture) { _ => refresh() }
 
-      val matchQuery = MultiMatchQueryWithOptions("multimatch1 test", Map("operator" -> "and"), "f1", "text")
+      val matchQuery = MultiMatchQuery("multimatch1 test", Map("operator" -> "and"), "f1", "text")
       val matchQueryFuture = restClient.query(index, tpe, new QueryRoot(matchQuery))
       matchQueryFuture.futureValue.sourceAsMap.toSet should be(Set(Map("f1" -> "multimatch1 test", "f2" -> 1, "text" -> "text1")))
     }

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -688,7 +688,7 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       val docsFuture = restClient.bulkIndex(index, tpe, Seq(multiMatchDoc1, multiMatchDoc2))
       whenReady(docsFuture) { _ => refresh() }
 
-      val matchQuery = MultiMatchQuery("multimatch1", "f1", "text")
+      val matchQuery = MultiMatchQueryWithOptions("multimatch1", Map(), "f1", "text")
       val matchQueryFuture = restClient.query(index, tpe, new QueryRoot(matchQuery))
       matchQueryFuture.futureValue.sourceAsMap.toSet should be(Set(Map("f1" -> "text1", "f2" -> 1, "text" -> "multimatch1"), Map("f1" -> "multimatch1", "f2" -> 1, "text" -> "text1")))
     }


### PR DESCRIPTION
Unify `MultiMatchQueryWithOptions` and `MultiMatchQuery` (issue here https://github.com/SumoLogic/elasticsearch-client/issues/71)