### PR TITLE
Release 2.0.0: Task 6 - fix a flaky test

### DIFF
--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -111,7 +111,7 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
     "Be able to create an index, index a document, and search it" in {
       indexDocs(Seq(Document("doc1", Map("text" -> "here"))))
       val resFut = restClient.query(index, tpe, new QueryRoot(TermQuery("text", "here"),
-        sortOpt = Some(Seq(SimpleSort("_timestamp", DescSortOrder))), timeoutOpt = Some(10)))
+        sortOpt = Some(Seq(SimpleSort("_timestamp", DescSortOrder))), timeoutOpt = None))
       whenReady(resFut) { res =>
         res.sourceAsMap.toList should be(List(Map("text" -> "here")))
       }
@@ -120,7 +120,7 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
     "Be able to delete a document that exists" in {
       indexDocs(Seq(Document("doc1", Map("text" -> "here"))))
       val resFut = restClient.query(index, tpe, new QueryRoot(TermQuery("text", "here"),
-        sortOpt = Some(Seq(SimpleSort("_timestamp", DescSortOrder))), timeoutOpt = Some(10)))
+        sortOpt = Some(Seq(SimpleSort("_timestamp", DescSortOrder))), timeoutOpt = None))
 
       val foundDoc: ElasticJsonDocument = whenReady(resFut){ res =>
         res.rawSearchResponse.hits.hits.head
@@ -135,7 +135,7 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       refresh()
 
       val resFut2 = restClient.query(index, tpe, new QueryRoot(TermQuery("text", "here"),
-        sortOpt = Some(Seq(SimpleSort("_timestamp", DescSortOrder))), timeoutOpt = Some(10)))
+        sortOpt = Some(Seq(SimpleSort("_timestamp", DescSortOrder))), timeoutOpt = None))
       whenReady(resFut2){ res =>
         res.rawSearchResponse.hits.hits.size should be(0)
       }

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -111,7 +111,7 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
     "Be able to create an index, index a document, and search it" in {
       indexDocs(Seq(Document("doc1", Map("text" -> "here"))))
       val resFut = restClient.query(index, tpe, new QueryRoot(TermQuery("text", "here"),
-        sortOpt = Some(Seq(SimpleSort("_timestamp", DescSortOrder))), timeoutOpt = None))
+        sortOpt = Some(Seq(SimpleSort("_timestamp", DescSortOrder))), timeoutOpt = Some(50000)))
       whenReady(resFut) { res =>
         res.sourceAsMap.toList should be(List(Map("text" -> "here")))
       }
@@ -120,7 +120,7 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
     "Be able to delete a document that exists" in {
       indexDocs(Seq(Document("doc1", Map("text" -> "here"))))
       val resFut = restClient.query(index, tpe, new QueryRoot(TermQuery("text", "here"),
-        sortOpt = Some(Seq(SimpleSort("_timestamp", DescSortOrder))), timeoutOpt = None))
+        sortOpt = Some(Seq(SimpleSort("_timestamp", DescSortOrder))), timeoutOpt = Some(5000)))
 
       val foundDoc: ElasticJsonDocument = whenReady(resFut){ res =>
         res.rawSearchResponse.hits.hits.head
@@ -135,7 +135,7 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       refresh()
 
       val resFut2 = restClient.query(index, tpe, new QueryRoot(TermQuery("text", "here"),
-        sortOpt = Some(Seq(SimpleSort("_timestamp", DescSortOrder))), timeoutOpt = None))
+        sortOpt = Some(Seq(SimpleSort("_timestamp", DescSortOrder))), timeoutOpt = Some(5000)))
       whenReady(resFut2){ res =>
         res.rawSearchResponse.hits.hits.size should be(0)
       }

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -105,7 +105,7 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
 
     "Be able to create an index, index a document, and search it" in {
       indexDocs(Seq(Document("doc1", Map("text" -> "here"))))
-      val resFut = restClient.query(index, tpe, new QueryRoot(TermQuery("text", "here"), timeoutOpt = Some(50000)))
+      val resFut = restClient.query(index, tpe, new QueryRoot(TermQuery("text", "here"), timeoutOpt = Some(5000)))
 
       whenReady(resFut) { res =>
         res.sourceAsMap.toList should be(List(Map("text" -> "here")))


### PR DESCRIPTION
Looks like we set the timeout on some tests that causing flakiness. In this PR I remove the timeout in these tests. 