### PR TITLE
Release 2.0.0: Task 7 - Fix json parsing for error response

### DIFF
--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -160,8 +160,8 @@ class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[
   def createIndex(index: Index, settings: Option[IndexSetting] = None): Future[RawJsonResponse] = {
     implicit val ec = indexExecutionCtx
     runEsCommand(CreateIndex(settings), s"/${index.name}").recover {
-      case ElasticErrorResponse(message, status) if message contains "IndexAlreadyExistsException" =>
-        throw new IndexAlreadyExistsException(message)
+      case ElasticErrorResponse(message, status) if message.toString contains "IndexAlreadyExistsException" =>
+        throw IndexAlreadyExistsException(message.toString)
     }
   }
 
@@ -234,7 +234,7 @@ class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[
       if (response.status.isFailure) {
         logger.warn(s"Failure response: ${entityString.take(500)}")
         logger.warn(s"Failing request: ${op.take(5000)}")
-        throw ElasticErrorResponse(entityString, response.status.intValue)
+        throw ElasticErrorResponse(JString(entityString), response.status.intValue)
       }
       RawJsonResponse(entityString)
     }
@@ -336,7 +336,7 @@ object RestlasticSearchClient {
 
     case class IndexAlreadyExistsException(message: String) extends Exception(message)
 
-    case class ElasticErrorResponse(error: String, status: Int) extends Exception(s"ElasticsearchError(status=$status): $error")
+    case class ElasticErrorResponse(error: JValue, status: Int) extends Exception(s"ElasticsearchError(status=$status): ${error.toString}")
 
     case class ScrollResponse(_scroll_id: String)
 

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -28,6 +28,8 @@ import com.sumologic.elasticsearch_test.ElasticsearchIntegrationTest
 import org.scalatest._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
+import org.json4s._
+import org.json4s.native.JsonMethods._
 
 class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFutures with BeforeAndAfterAll
   with ElasticsearchIntegrationTest with OneInstancePerTest {
@@ -269,6 +271,21 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
         val elasticErrorResponse = e.asInstanceOf[ElasticErrorResponse]
         elasticErrorResponse.status should be(404)
       }
+    }
+
+    "Be able to parse error in response as a json object" in {
+      implicit val formats = org.json4s.DefaultFormats
+      val errorDocumentMissing =
+        """{"error":{"root_cause":[{"type":"document_missing_exception",
+          |"reason":"[engine_product][37035513]: document missing","shard":"1","index":"product"}],
+          |"type":"document_missing_exception",
+          |"reason":"[engine_product][37035513]: document missing",
+          |"shard":"1",
+          |"index":"product"},
+          |"status":404} """.stripMargin
+      val jsonTree = parse(errorDocumentMissing)
+      val errorMessage = jsonTree.extract[ElasticErrorResponse]
+      errorMessage.error should be(jsonTree \\ "error")
     }
 
     "Support delete documents" in {


### PR DESCRIPTION
Please refer to issue here https://github.com/SumoLogic/elasticsearch-client/issues/65

ElasticErrorResponse now accepts `error` as a `JValue` as compared to `String` in the previous implementation