### PR TITLE
Upgrade Elasticsearch version to 2.3

### DIFF
--- a/elasticsearch-core/pom.xml
+++ b/elasticsearch-core/pom.xml
@@ -69,21 +69,21 @@
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-core</artifactId>
-      <version>4.10.4</version>
+      <version>${lucene.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-analyzers-common</artifactId>
-      <version>4.10.4</version>
+      <version>${lucene.version}</version>
       <scope>test</scope>
     </dependency>
 
     <dependency>
       <groupId>org.elasticsearch</groupId>
       <artifactId>elasticsearch</artifactId>
-      <version>1.6.2</version>
+      <version>${elasticsearch.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -160,7 +160,7 @@ class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[
   def createIndex(index: Index, settings: Option[IndexSetting] = None): Future[RawJsonResponse] = {
     implicit val ec = indexExecutionCtx
     runEsCommand(CreateIndex(settings), s"/${index.name}").recover {
-      case ElasticErrorResponse(message, status) if message contains "IndexAlreadyExistsException" =>
+      case ElasticErrorResponse(message, status) if message contains "index_already_exists_exception" =>
         throw new IndexAlreadyExistsException(message)
     }
   }

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -257,9 +257,10 @@ object RestlasticSearchClient {
     case class ScrollId(id: String)
 
     case class BulkIndexResponse(items: List[Map[String, BulkItem]])
-    case class BulkItem(_index: String, _type: String, _id: String, status: Int, error: Option[String]) {
+    case class BulkIndexError(reason: String)
+    case class BulkItem(_index: String, _type: String, _id: String, status: Int, error: Option[BulkIndexError]) {
       def created = status > 200 && status < 299 && !alreadyExists
-      def alreadyExists = error.exists(_.contains("DocumentAlreadyExists"))
+      def alreadyExists = error.exists(_.reason.contains("document already exists"))
       def success = status >= 200 && status <= 299
     }
 

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -275,6 +275,7 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       }
       val delFut = restClient.deleteDocument(index, tpe, new QueryRoot(TermQuery("text7", "here7")))
       Await.result(delFut, 10.seconds)
+      refresh()
       val resFut1 = restClient.query(index, tpe, new QueryRoot(TermQuery("text7", "here7")))
       whenReady(resFut1) { res =>
         res.sourceAsMap.toList should be(List())

--- a/elasticsearch-test/pom.xml
+++ b/elasticsearch-test/pom.xml
@@ -27,35 +27,29 @@
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-core</artifactId>
-      <version>4.10.4</version>
+      <version>${lucene.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.apache.lucene</groupId>
       <artifactId>lucene-analyzers-common</artifactId>
-      <version>4.10.4</version>
+      <version>${lucene.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.elasticsearch</groupId>
       <artifactId>elasticsearch</artifactId>
-      <version>1.6.2</version>
+      <version>${elasticsearch.version}</version>
     </dependency>
 
     <dependency>
       <groupId>org.elasticsearch</groupId>
       <artifactId>elasticsearch</artifactId>
-      <version>1.6.2</version>
+      <version>${elasticsearch.version}</version>
       <type>test-jar</type>
     </dependency>
 
     <!-- Non-Sumo Test Dependencies. -->
-    <dependency>
-      <groupId>org.apache.lucene</groupId>
-      <artifactId>lucene-test-framework</artifactId>
-      <version>4.10.4</version>
-    </dependency>
-
     <dependency>
       <groupId>org.scalatest</groupId>
       <artifactId>scalatest_${scala.version.major}</artifactId>

--- a/elasticsearch-test/src/main/scala/com/sumologic/elasticsearch_test/ElasticsearchIntegrationTest.scala
+++ b/elasticsearch-test/src/main/scala/com/sumologic/elasticsearch_test/ElasticsearchIntegrationTest.scala
@@ -22,7 +22,7 @@ import java.io.File
 
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest
 import org.elasticsearch.client.transport.TransportClient
-import org.elasticsearch.common.settings.ImmutableSettings
+import org.elasticsearch.common.settings.Settings
 import org.elasticsearch.common.transport.{InetSocketTransportAddress, LocalTransportAddress}
 import org.elasticsearch.node.NodeBuilder
 import org.scalatest.{BeforeAndAfterAll, Suite}
@@ -71,10 +71,10 @@ trait ElasticsearchIntegrationTest extends BeforeAndAfterAll {
 
 object ElasticsearchIntegrationTest {
   private val r = new Random()
-  private lazy val esNodeSettings = ImmutableSettings.settingsBuilder().put("path.data", createTempDir("elasticsearch-test")).build()
+  private lazy val esNodeSettings = Settings.builder().put("path.home", createTempDir("elasticsearch-test")).build()
   private lazy val esNode = NodeBuilder.nodeBuilder().local(true).settings(esNodeSettings).node()
-  private lazy val settings = ImmutableSettings.settingsBuilder().put("node.local", "true").build()
-  lazy val client = new TransportClient(settings).addTransportAddress(new LocalTransportAddress("1"))
+  private lazy val settings = Settings.builder().put("node.local", "true").build()
+  lazy val client = esNode.client()
   lazy val globalEndpoint = {
     val nodeInfos = client.admin().cluster().prepareNodesInfo().clear().setSettings(true).setHttp(true).get()
     val nodeAddress =

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <properties>
         <scala.version.major>2.11</scala.version.major>
         <akka.version>2.3.11</akka.version>
-        <elasticsearch.version>2.3.0</elasticsearch.version>
+        <elasticsearch.version>2.3.5</elasticsearch.version>
         <lucene.version>5.5.0</lucene.version>
     </properties>
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -27,6 +27,8 @@
     <properties>
         <scala.version.major>2.11</scala.version.major>
         <akka.version>2.3.11</akka.version>
+        <elasticsearch.version>2.3.0</elasticsearch.version>
+        <lucene.version>5.5.0</lucene.version>
     </properties>
     <dependencies>
         <dependency>


### PR DESCRIPTION
This submission upgrade ES to version 2.3. I was originally trying to upgrade to 5.1 directly. Unfortunately, I had to stop and go for 2.3 due to
- Elasticsearch 5.x requires java 8 and our code base is still at java 7
- Migrate from 1.x to 5.x is not supported in Elasticsearch ([Breaking Changes](https://www.elastic.co/guide/en/elasticsearch/reference/current/breaking-changes.html)) and AWS [http://docs.aws.amazon.com/elasticsearch-service/latest/developerguide/es-version-migration.html]
- There were many breaking changes that requires api changes between 1.x to 5.x. It will be a big hurdle for users of the library to go from 1.x to 5.x. 

The changes in this submission include:
1. Upgrade of elasticsearch version to 2.3 and 5.5
2. Fix breaking changes in index already exists exception
3. Fix breaking changes in document already exists exception
4. Fix breaking changes in delete by query removed from core and became a plugin. AWS does not seem to have this plugin supported though (https://forums.aws.amazon.com/thread.jspa?threadID=247649). 
    In this change, if delete by query plugin is enabled, then we can use it. Otherwise, the execution via query, and bulkDelete.