### PR TITLE
Add doucmentExistsById api

### DIFF
--- a/elasticsearch-akka/pom.xml
+++ b/elasticsearch-akka/pom.xml
@@ -53,7 +53,7 @@
     <dependency>
       <groupId>com.typesafe.akka</groupId>
       <artifactId>akka-stream-experimental_${scala.version.major}</artifactId>
-      <version>2.0.1-SNAPSHOT</version>
+      <version>2.0.1</version>
     </dependency>
 
     <dependency>

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -124,8 +124,7 @@ class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[
     implicit val ec = indexExecutionCtx
     runEsCommand(NoOp, s"/${index.name}/${tpe.name}/$id", DELETE).map(_.mappedTo[DeleteResponse])
   }
-
-  // Returns true if document exists, returns ElasticErrorResponse with status = 404 otherwise
+  
   def documentExistsById(index: Index, tpe: Type, id: String): Future[Boolean] = {
     implicit val ec = indexExecutionCtx
     runEsCommand(NoOp, s"/${index.name}/${tpe.name}/$id", HEAD).map(_ => true).recover {

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -125,6 +125,12 @@ class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[
     runEsCommand(NoOp, s"/${index.name}/${tpe.name}/$id", DELETE).map(_.mappedTo[DeleteResponse])
   }
 
+  // Returns true if document exists, returns ElasticErrorResponse with status = 404 otherwise
+  def doucmentExistsById(index: Index, tpe: Type, id: String): Future[Boolean] = {
+    implicit val ec = indexExecutionCtx
+    runEsCommand(NoOp, s"/${index.name}/${tpe.name}/$id", HEAD).map(_ => true)
+  }
+
   def bulkIndex(bulk: Bulk): Future[Seq[BulkItem]] = {
     implicit val ec = indexExecutionCtx
     runEsCommand(bulk, s"/_bulk").map { resp =>

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -126,9 +126,12 @@ class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[
   }
 
   // Returns true if document exists, returns ElasticErrorResponse with status = 404 otherwise
-  def doucmentExistsById(index: Index, tpe: Type, id: String): Future[Boolean] = {
+  def documentExistsById(index: Index, tpe: Type, id: String): Future[Boolean] = {
     implicit val ec = indexExecutionCtx
-    runEsCommand(NoOp, s"/${index.name}/${tpe.name}/$id", HEAD).map(_ => true)
+    runEsCommand(NoOp, s"/${index.name}/${tpe.name}/$id", HEAD).map(_ => true).recover {
+      case ex: ElasticErrorResponse if ex.status == 404 =>
+        false
+    }
   }
 
   def bulkIndex(bulk: Bulk): Future[Seq[BulkItem]] = {

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -932,9 +932,7 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       val doc = Document("doc0001", Map("text" -> "here"))
       val indexFuture = restClient.bulkIndex(index, tpe, Seq(doc))
       whenReady(indexFuture) { _ => refresh() }
-      // verify doc0001 exists
       restClient.documentExistsById(index, tpe, "doc0001").futureValue should be(true)
-      // verify doc0002 does not exist
       restClient.documentExistsById(index, tpe, "doc0002").futureValue should be(false)
     }
 

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -18,7 +18,6 @@
  */
 package com.sumologic.elasticsearch.restlastic
 
-import com.sumologic.elasticsearch.restlastic.RestlasticSearchClient.ReturnTypes
 import com.sumologic.elasticsearch.restlastic.RestlasticSearchClient.ReturnTypes._
 import com.sumologic.elasticsearch.restlastic.dsl.Dsl._
 import com.sumologic.elasticsearch_test.ElasticsearchIntegrationTest

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -933,14 +933,9 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       val indexFuture = restClient.bulkIndex(index, tpe, Seq(doc))
       whenReady(indexFuture) { _ => refresh() }
       // verify doc0001 exists
-      restClient.doucmentExistsById(index, tpe, "doc0001").futureValue should be(true)
+      restClient.documentExistsById(index, tpe, "doc0001").futureValue should be(true)
       // verify doc0002 does not exist
-      try {
-        Await.result(restClient.doucmentExistsById(index, tpe, "doc0002"), 10.seconds)
-      } catch {
-        case ex: ElasticErrorResponse =>
-          ex.status should be(404)
-      }
+      restClient.documentExistsById(index, tpe, "doc0002").futureValue should be(false)
     }
 
     def indexDocs(docs: Seq[Document]): Unit = {


### PR DESCRIPTION
Add an api to efficiently check if a document already exists as described here https://www.elastic.co/guide/en/elasticsearch/guide/current/doc-exists.html