### PR TITLE
Add a size option to ScanAndScrollSource

### DIFF
--- a/elasticsearch-akka/src/main/scala/com/sumologic/elasticsearch/akkahelpers/ScanAndScrollSource.scala
+++ b/elasticsearch-akka/src/main/scala/com/sumologic/elasticsearch/akkahelpers/ScanAndScrollSource.scala
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory
  * @param scrollSource Raw ES scroll interface
  */
 
-class ScanAndScrollSource(index: Index, tpe: Type, query: QueryRoot, scrollSource: ScrollClient, sizeOpt: Option[Int])
+class ScanAndScrollSource(index: Index, tpe: Type, query: QueryRoot, scrollSource: ScrollClient, sizeOpt: Option[Int] = None)
   extends ActorPublisher[SearchResponse]
   with FSM[ScanState, ScanData] {
 

--- a/elasticsearch-akka/src/test/scala/com/sumologic/elasticsearch/akkahelpers/ScanAndScrollSourceTest.scala
+++ b/elasticsearch-akka/src/test/scala/com/sumologic/elasticsearch/akkahelpers/ScanAndScrollSourceTest.scala
@@ -51,7 +51,7 @@ class ScanAndScrollSourceTest extends WordSpec with Matchers with ScalaFutures {
     "Read to the end of a source" in {
       val searchResponses = resultMaps.map(searchResponseFromMap)
       val client = new MockScrollClient(searchResponses)
-      val source = Source.actorPublisher[SearchResponse](ScanAndScrollSource.props(index, tpe, queryRoot, client))
+      val source = Source.actorPublisher[SearchResponse](ScanAndScrollSource.props(index, tpe, queryRoot, client, sizeOpt = Some(5)))
       val fut = source
         .map(_.sourceAsMap)
         .grouped(10)


### PR DESCRIPTION
- There was a 5x performance regression in the new client version 2.0.x (with old server version 1.5). 
- We have to make the new client compatible with old server version for the no down-time upgrade. 
- Regression is centered around scan of documents. 
The root cause seems to be that Elasticsearch defaults to a scan size of 10, which is problematic with massive migrations. https://github.com/elastic/elasticsearch/issues/18253
The previous client version may get around with this due to the very efficient `scan` type which has been removed in the new client version. 

In this PR, I added a sizeOpt to ScanAndScrollSource that controls the scan size. 