### PR TITLE
BulkIndexActor And ScanAndScrollSource to use right execution context

### DIFF
--- a/elasticsearch-akka/src/main/scala/com/sumologic/elasticsearch/akkahelpers/BulkIndexerActor.scala
+++ b/elasticsearch-akka/src/main/scala/com/sumologic/elasticsearch/akkahelpers/BulkIndexerActor.scala
@@ -49,8 +49,6 @@ class BulkIndexerActor(restlasticSearchClient: RestlasticSearchClient, bulkConfi
   case class OpWithTarget(operation: BulkOperation, target: ActorRef, sessionId: BulkSession)
   var queue = List.empty[OpWithTarget]
 
-  import scala.concurrent.ExecutionContext.Implicits.global
-
   private def resetTimer() = context.system.scheduler.scheduleOnce(bulkConfig.flushDuration(), self, ForceFlush)
   var flushTimer = resetTimer()
 
@@ -85,6 +83,8 @@ class BulkIndexerActor(restlasticSearchClient: RestlasticSearchClient, bulkConfi
   private def ago(millis: Long) = now - millis
 
   private def flush(): Unit = {
+    implicit val ec = restlasticSearchClient.indexExecutionCtx
+
     if (queue.isEmpty) {
       flushTimer = resetTimer()
       return

--- a/elasticsearch-akka/src/main/scala/com/sumologic/elasticsearch/akkahelpers/BulkIndexerActor.scala
+++ b/elasticsearch-akka/src/main/scala/com/sumologic/elasticsearch/akkahelpers/BulkIndexerActor.scala
@@ -43,6 +43,7 @@ case class BulkConfig(flushDuration: () => FiniteDuration, maxDocuments: () => I
  */
 class BulkIndexerActor(restlasticSearchClient: RestlasticSearchClient, bulkConfig: BulkConfig) extends Actor {
   import BulkIndexerActor._
+  implicit val ec = restlasticSearchClient.indexExecutionCtx
 
   val logger = LoggerFactory.getLogger(BulkIndexerActor.getClass)
 
@@ -83,7 +84,6 @@ class BulkIndexerActor(restlasticSearchClient: RestlasticSearchClient, bulkConfi
   private def ago(millis: Long) = now - millis
 
   private def flush(): Unit = {
-    implicit val ec = restlasticSearchClient.indexExecutionCtx
 
     if (queue.isEmpty) {
       flushTimer = resetTimer()

--- a/elasticsearch-akka/src/main/scala/com/sumologic/elasticsearch/akkahelpers/ScanAndScrollSource.scala
+++ b/elasticsearch-akka/src/main/scala/com/sumologic/elasticsearch/akkahelpers/ScanAndScrollSource.scala
@@ -49,7 +49,7 @@ class ScanAndScrollSource(index: Index, tpe: Type, query: QueryRoot, scrollSourc
   import akka.stream.actor.ActorPublisherMessage
 
   import ScanAndScrollSource._
-  import scala.concurrent.ExecutionContext.Implicits.global
+  implicit val ec = scrollSource.indexExecutionCtx
 
   val logger = LoggerFactory.getLogger(ScanAndScrollSource.getClass)
   override def preStart(): Unit = {

--- a/elasticsearch-akka/src/test/scala/com/sumologic/elasticsearch/akkahelpers/ScanAndScrollSourceTest.scala
+++ b/elasticsearch-akka/src/test/scala/com/sumologic/elasticsearch/akkahelpers/ScanAndScrollSourceTest.scala
@@ -30,7 +30,7 @@ import org.json4s._
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.{Matchers, WordSpec}
 
-import scala.concurrent.Future
+import scala.concurrent.{ExecutionContext, Future}
 
 class ScanAndScrollSourceTest extends WordSpec with Matchers with ScalaFutures {
   val resultMaps: List[Map[String, AnyRef]] = List(Map("a" -> "1"), Map("a" -> "2"), Map("a" -> "3"))
@@ -68,6 +68,7 @@ class MockScrollClient(results: List[SearchResponse]) extends ScrollClient {
   var id = 1
   var started = false
   var resultsQueue = results
+  override val indexExecutionCtx: ExecutionContext = ExecutionContext.Implicits.global
   override def startScrollRequest(index: Dsl.Index, tpe: Dsl.Type, query: Dsl.QueryRoot,
                                   resultWindowOpt: Option[String] = None, fromOpt: Option[Int] = None, sizeOpt: Option[Int] = None): Future[(ScrollId, SearchResponse)] = {
     if (!started) {

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -65,7 +65,7 @@ trait RequestSigner {
  * @param endpointProvider EndpointProvider
  */
 class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[RequestSigner] = None,
-                             indexExecutionCtx: ExecutionContext = ExecutionContext.Implicits.global,
+                             val indexExecutionCtx: ExecutionContext = ExecutionContext.Implicits.global,
                              searchExecutionCtx: ExecutionContext = ExecutionContext.Implicits.global)
                             (implicit val system: ActorSystem = ActorSystem(), val timeout: Timeout = Timeout(30.seconds))
   extends ScrollClient {

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -39,6 +39,7 @@ import scala.concurrent.duration._
 trait ScrollClient {
   import Dsl._
   val defaultResultWindow = "1m"
+  val indexExecutionCtx: ExecutionContext = ExecutionContext.Implicits.global
   def startScrollRequest(index: Index, tpe: Type, query: QueryRoot, resultWindowOpt: Option[String] = None, fromOpt: Option[Int] = None, sizeOpt: Option[Int] = None): Future[(ScrollId, SearchResponse)]
   def scroll(scrollId: ScrollId, resultWindowOpt: Option[String] = None): Future[(ScrollId, SearchResponse)]
 }
@@ -65,7 +66,7 @@ trait RequestSigner {
  * @param endpointProvider EndpointProvider
  */
 class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[RequestSigner] = None,
-                             val indexExecutionCtx: ExecutionContext = ExecutionContext.Implicits.global,
+                             override val indexExecutionCtx: ExecutionContext = ExecutionContext.Implicits.global,
                              searchExecutionCtx: ExecutionContext = ExecutionContext.Implicits.global)
                             (implicit val system: ActorSystem = ActorSystem(), val timeout: Timeout = Timeout(30.seconds))
   extends ScrollClient {


### PR DESCRIPTION
Currently BulkIndexerActor & ScanAndScrollSource is using the global execution context. It should use the ingest execution context passed in as defined in

```
class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[RequestSigner] = None,
                             val indexExecutionCtx: ExecutionContext = ExecutionContext.Implicits.global,
                             searchExecutionCtx: ExecutionContext = ExecutionContext.Implicits.global)
```