### PR TITLE
MET-5280 deleteDocument API doesn't delete all the matching items

### DIFF
--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -180,12 +180,20 @@ class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[
     runEsCommand(EmptyObject, s"/${index.name}", DELETE)
   }
 
+  @deprecated("Use deleteDocuments instead")
   def deleteDocument(index: Index, tpe: Type, deleteQuery: QueryRoot, pluginEnabled: Boolean = false): Future[RawJsonResponse] = {
     implicit val ec = indexExecutionCtx
     if (pluginEnabled) {
       runEsCommand(deleteQuery, s"/${index.name}/${tpe.name}/_query", DELETE)
     } else {
-      val documents = Await.result(query(index, tpe, deleteQuery, rawJsonStr = false), 10.seconds).rawSearchResponse.hits.hits.map(_._id)
+      val response = Await.result(query(index, tpe, deleteQuery, rawJsonStr = false), 10.seconds).rawSearchResponse
+      val totalHits = response.hits.total
+      val documents = response.hits.hits.map(_._id)
+      if (totalHits > documents.length) {
+        logger.warn(s"deleting only first ${documents.length}/$totalHits matches. " +
+          "Use deleteDocuments, if you want to delete more at once.")
+      }
+
       bulkDelete(index, tpe, documents.map(Document(_, Map()))).map(res => RawJsonResponse(res.toString))
     }
   }

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -180,7 +180,7 @@ class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[
     runEsCommand(EmptyObject, s"/${index.name}", DELETE)
   }
 
-  @deprecated("Use deleteDocuments instead")
+  @deprecated("When plugin is not enabled this function doesn't handle pagination, so it deletes only first page of query results. Replaced by deleteDocuments.")
   def deleteDocument(index: Index, tpe: Type, deleteQuery: QueryRoot, pluginEnabled: Boolean = false): Future[RawJsonResponse] = {
     implicit val ec = indexExecutionCtx
     if (pluginEnabled) {

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -936,6 +936,25 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       restClient.documentExistsById(index, tpe, "doc0002").futureValue should be(false)
     }
 
+    "Support deleting more than 10000 docs" in {
+      val insertFutures = (1 to 10011).map(i => restClient.index(index, tpe, Document(s"doc$i", Map("text7" -> "here7"))))
+      val ir = Future.sequence(insertFutures)
+      Await.result(ir, 20.seconds)
+      refresh()
+
+      val delFut = restClient.deleteDocuments(index, tpe, new QueryRoot(MatchAll, sizeOpt = Some(9)))
+      Await.result(delFut, 20.seconds)
+      refresh()
+
+      val count = Await.result(restClient.count(index, tpe, new QueryRoot(MatchAll)), 10.seconds)
+      count should be (0)
+    }
+
+    "Support deleting a doc that doesn't exist" in {
+      val delFut = restClient.deleteDocuments(index, tpe, new QueryRoot(TermQuery("text7", "here7")))
+      Await.result(delFut, 10.seconds) // May not need Await?
+    }
+
     def indexDocs(docs: Seq[Document]): Unit = {
       val bulkIndexFuture = restClient.bulkIndex(index, tpe, docs)
       whenReady(bulkIndexFuture) { _ => refresh() }


### PR DESCRIPTION
I believe there is no optimal solution here. The problem is the return type of deleteDocument.  I'm not sure what should we return in such case. One idea is to return an artificial JSON, obtained by joining all responses, that sounds awful. So I've decided to use different signature and create a new function ("deleteDocuments").

There is one downside though - if one is going to delete really many documents the result is going to blow up the memory. To solve this we could turn deleteDocuments into some kind of streaming operation, but I feel that it would be an overkill.