### PR TITLE
Pass in sizeOpt to deleteDocuments request

### DIFF
--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -198,8 +198,8 @@ class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[
     }
   }
 
-  def deleteDocuments(index: Index, tpe: Type, deleteQuery: QueryRoot, pluginEnabled: Boolean = false): Future[Map[Index, DeleteResponse]] = {
-    def firstScroll(scId: ScrollId) = startScrollRequest(index, tpe, deleteQuery)
+  def deleteDocuments(index: Index, tpe: Type, deleteQuery: QueryRoot, pluginEnabled: Boolean = false, sizeOpt: Option[Int] = None): Future[Map[Index, DeleteResponse]] = {
+    def firstScroll(scId: ScrollId) = startScrollRequest(index, tpe, deleteQuery, sizeOpt = sizeOpt)
 
     scrollDelete(index, tpe, ScrollId(""), Map.empty[Index, DeleteResponse], firstScroll)
   }


### PR DESCRIPTION
The default size for query is 10 per-shard. This results in very bad performance when running scanAndScroll request. This PR allows a user given batch size to be passed in. 