### PR TITLE
Add retry on version conflict option

### DIFF
--- a/elasticsearch-akka/src/main/scala/com/sumologic/elasticsearch/akkahelpers/BulkIndexerActor.scala
+++ b/elasticsearch-akka/src/main/scala/com/sumologic/elasticsearch/akkahelpers/BulkIndexerActor.scala
@@ -63,8 +63,8 @@ class BulkIndexerActor(restlasticSearchClient: RestlasticSearchClient, bulkConfi
       queue = OpWithTarget(BulkOperation(index, Some(indexName -> tpe), doc), sender(), sess) :: queue
       if (queueFull) flush()
 
-    case UpdateRequest(sess, index, tpe, doc, retryOnVersionConflictOpt) =>
-      queue = OpWithTarget(BulkOperation(update, Some(index -> tpe), doc, retryOnVersionConflictOpt), sender(), sess) :: queue
+    case UpdateRequest(sess, index, tpe, doc, retryOnConflictOpt) =>
+      queue = OpWithTarget(BulkOperation(update, Some(index -> tpe), doc, retryOnConflictOpt), sender(), sess) :: queue
       if (queueFull) flush()
 
     case ForceFlush => flush()
@@ -131,7 +131,7 @@ object BulkIndexerActor {
   // Messages
   case class CreateRequest(sessionId: BulkSession, index: Index, tpe: Type, doc: Document)
   case class IndexRequest(sessionId: BulkSession, index: Index, tpe: Type, doc: Document)
-  case class UpdateRequest(sessionId: BulkSession, index: Index, tpe: Type, doc: Document, retryOnVersionConflictOpt: Option[Int] = None)
+  case class UpdateRequest(sessionId: BulkSession, index: Index, tpe: Type, doc: Document, retryOnConflictOpt: Option[Int] = None)
   case object ForceFlush
 
   // Replies

--- a/elasticsearch-akka/src/main/scala/com/sumologic/elasticsearch/akkahelpers/BulkIndexerActor.scala
+++ b/elasticsearch-akka/src/main/scala/com/sumologic/elasticsearch/akkahelpers/BulkIndexerActor.scala
@@ -63,8 +63,8 @@ class BulkIndexerActor(restlasticSearchClient: RestlasticSearchClient, bulkConfi
       queue = OpWithTarget(BulkOperation(index, Some(indexName -> tpe), doc), sender(), sess) :: queue
       if (queueFull) flush()
 
-    case UpdateRequest(sess, index, tpe, doc) =>
-      queue = OpWithTarget(BulkOperation(update, Some(index -> tpe), doc), sender(), sess) :: queue
+    case UpdateRequest(sess, index, tpe, doc, retryOnVersionConflictOpt) =>
+      queue = OpWithTarget(BulkOperation(update, Some(index -> tpe), doc, retryOnVersionConflictOpt), sender(), sess) :: queue
       if (queueFull) flush()
 
     case ForceFlush => flush()
@@ -131,7 +131,7 @@ object BulkIndexerActor {
   // Messages
   case class CreateRequest(sessionId: BulkSession, index: Index, tpe: Type, doc: Document)
   case class IndexRequest(sessionId: BulkSession, index: Index, tpe: Type, doc: Document)
-  case class UpdateRequest(sessionId: BulkSession, index: Index, tpe: Type, doc: Document)
+  case class UpdateRequest(sessionId: BulkSession, index: Index, tpe: Type, doc: Document, retryOnVersionConflictOpt: Option[Int] = None)
   case object ForceFlush
 
   // Replies

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -147,8 +147,8 @@ class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[
     bulkIndex(bulkOperation)
   }
 
-  def bulkUpdate(index: Index, tpe: Type, documents: Seq[Document], retryOnVersionConflictOpt: Option[Int] = None): Future[Seq[BulkItem]] = {
-    val bulkOperation = Bulk(documents.map(BulkOperation(update, Some(index -> tpe), _, retryOnVersionConflictOpt)))
+  def bulkUpdate(index: Index, tpe: Type, documents: Seq[Document], retryOnConflictOpt: Option[Int] = None): Future[Seq[BulkItem]] = {
+    val bulkOperation = Bulk(documents.map(BulkOperation(update, Some(index -> tpe), _, retryOnConflictOpt)))
     bulkIndex(bulkOperation)
   }
   

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -147,8 +147,8 @@ class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[
     bulkIndex(bulkOperation)
   }
 
-  def bulkUpdate(index: Index, tpe: Type, documents: Seq[Document]): Future[Seq[BulkItem]] = {
-    val bulkOperation = Bulk(documents.map(BulkOperation(update, Some(index -> tpe), _)))
+  def bulkUpdate(index: Index, tpe: Type, documents: Seq[Document], retryOnVersionConflictOpt: Option[Int] = None): Future[Seq[BulkItem]] = {
+    val bulkOperation = Bulk(documents.map(BulkOperation(update, Some(index -> tpe), _, retryOnVersionConflictOpt)))
     bulkIndex(bulkOperation)
   }
   

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/IndexDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/IndexDsl.scala
@@ -51,13 +51,13 @@ trait IndexDsl extends DslCommons {
     override lazy val toJsonStr = operations.map(_.toJsonStr).mkString("", "\n", "\n")
   }
 
-  case class BulkOperation(operation: OperationType, location: Option[(Index, Type)], document: Document, retryOnVersionConflictOpt: Option[Int] = None) extends EsOperation {
+  case class BulkOperation(operation: OperationType, location: Option[(Index, Type)], document: Document, retryOnConflictOpt: Option[Int] = None) extends EsOperation {
     import EsOperation.compactJson
     override def toJson: Map[String, Any] = throw new UnsupportedOperationException
     def toJsonStr: String = {
       val (doc, retryOpt) = operation match {
         case `update` =>
-          (Document(document.id, Map("doc"->document.data) ++ Map("detect_noop" -> true, "doc_as_upsert" -> true)), retryOnVersionConflictOpt.map(n => Map("_retry_on_conflict" -> n)))
+          (Document(document.id, Map("doc"->document.data) ++ Map("detect_noop" -> true, "doc_as_upsert" -> true)), retryOnConflictOpt.map(n => Map("_retry_on_conflict" -> n)))
         case _ => (document, None)
       }
 

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/IndexDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/IndexDsl.scala
@@ -51,17 +51,18 @@ trait IndexDsl extends DslCommons {
     override lazy val toJsonStr = operations.map(_.toJsonStr).mkString("", "\n", "\n")
   }
 
-  case class BulkOperation(operation: OperationType, location: Option[(Index, Type)], document: Document) extends EsOperation {
+  case class BulkOperation(operation: OperationType, location: Option[(Index, Type)], document: Document, retryOnVersionConflictOpt: Option[Int] = None) extends EsOperation {
     import EsOperation.compactJson
     override def toJson: Map[String, Any] = throw new UnsupportedOperationException
     def toJsonStr: String = {
-      val doc = operation match {
+      val (doc, retryOpt) = operation match {
         case `update` =>
-          Document(document.id, Map("doc"->document.data) ++ Map("detect_noop" -> true, "doc_as_upsert" -> true))
-        case _ => document
+          (Document(document.id, Map("doc"->document.data) ++ Map("detect_noop" -> true, "doc_as_upsert" -> true)), retryOnVersionConflictOpt.map(n => Map("_retry_on_conflict" -> n)))
+        case _ => (document, None)
       }
+
       val jsonObjects = Map(operation.jsonStr ->
-        (Map("_id" -> doc.id) ++ location.map { case (index, tpe) => Map("_index" -> index.name, "_type" -> tpe.name)}.getOrElse(Map()))
+        (Map("_id" -> doc.id) ++ location.map { case (index, tpe) => Map("_index" -> index.name, "_type" -> tpe.name)}.getOrElse(Map()) ++ retryOpt.getOrElse(Map()))
       )
       operation match {
         case `delete` => s"${compactJson(jsonObjects)}"

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -229,7 +229,7 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       Future.sequence(bulkUpdateFuture).futureValue.toString().contains("version conflict") should be(true)
 
       val bulkUpdateFutureWithRetry = (1 to 5).map { _ =>
-        restClient.bulkUpdate(index, tpe, Seq(docUpdate1, docUpdate2, docUpdate3), retryOnVersionConflictOpt = Some(100))
+        restClient.bulkUpdate(index, tpe, Seq(docUpdate1, docUpdate2, docUpdate3), retryOnConflictOpt = Some(100))
       }
       Future.sequence(bulkUpdateFutureWithRetry).futureValue.toString().contains("version conflict") should be(false)
     }

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -213,6 +213,27 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       }
     }
 
+    "Support bulk updates with retry on conflict" in {
+
+      val doc = Document("doc", Map("text" -> "retry on version conflict"))
+      val indexFuture = restClient.index(index, tpe, doc)
+      indexFuture.futureValue.created should be(true)
+
+      val docUpdate1 = Document("doc", Map("text" -> "retry on version conflict 1"))
+      val docUpdate2 = Document("doc", Map("text" -> "retry on version conflict 2"))
+      val docUpdate3 = Document("doc", Map("text" -> "retry on version conflict 3"))
+
+      val bulkUpdateFuture = (1 to 5).map { _ =>
+        restClient.bulkUpdate(index, tpe, Seq(docUpdate1, docUpdate2, docUpdate3))
+      }
+      Future.sequence(bulkUpdateFuture).futureValue.toString().contains("version conflict") should be(true)
+
+      val bulkUpdateFutureWithRetry = (1 to 5).map { _ =>
+        restClient.bulkUpdate(index, tpe, Seq(docUpdate1, docUpdate2, docUpdate3), retryOnVersionConflictOpt = Some(100))
+      }
+      Future.sequence(bulkUpdateFutureWithRetry).futureValue.toString().contains("version conflict") should be(false)
+    }
+
     "Support scroll requests" in {
       val docFutures = (1 to 10).map { n =>
         Document(s"doc-$n", Map("ct" -> "ct", "id" -> n))


### PR DESCRIPTION
When we have multiple parallel bulkUpdates operations, it can result in version conflict. The default behavior is to throw error. 

In the PR, I added the option of _retry_on_conflict. 