### PR TITLE
Support partition document updates with whole document upserts

### DIFF
--- a/elasticsearch-akka/src/main/scala/com/sumologic/elasticsearch/akkahelpers/BulkIndexerActor.scala
+++ b/elasticsearch-akka/src/main/scala/com/sumologic/elasticsearch/akkahelpers/BulkIndexerActor.scala
@@ -63,8 +63,8 @@ class BulkIndexerActor(restlasticSearchClient: RestlasticSearchClient, bulkConfi
       queue = OpWithTarget(BulkOperation(index, Some(indexName -> tpe), doc), sender(), sess) :: queue
       if (queueFull) flush()
 
-    case UpdateRequest(sess, index, tpe, doc, retryOnConflictOpt) =>
-      queue = OpWithTarget(BulkOperation(update, Some(index -> tpe), doc, retryOnConflictOpt), sender(), sess) :: queue
+    case UpdateRequest(sess, index, tpe, doc, retryOnConflictOpt, upsertOpt) =>
+      queue = OpWithTarget(BulkOperation(update, Some(index -> tpe), doc, retryOnConflictOpt, upsertOpt), sender(), sess) :: queue
       if (queueFull) flush()
 
     case ForceFlush => flush()
@@ -131,7 +131,7 @@ object BulkIndexerActor {
   // Messages
   case class CreateRequest(sessionId: BulkSession, index: Index, tpe: Type, doc: Document)
   case class IndexRequest(sessionId: BulkSession, index: Index, tpe: Type, doc: Document)
-  case class UpdateRequest(sessionId: BulkSession, index: Index, tpe: Type, doc: Document, retryOnConflictOpt: Option[Int] = None)
+  case class UpdateRequest(sessionId: BulkSession, index: Index, tpe: Type, doc: Document, retryOnConflictOpt: Option[Int] = None, upsertOpt: Option[Document] = None)
   case object ForceFlush
 
   // Replies

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -154,6 +154,12 @@ class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[
     val bulkOperation = if(upsertsOpt.isEmpty) {
       Bulk(documents.map(BulkOperation(update, Some(index -> tpe), _, retryOnConflictOpt)))
     } else {
+      val upsertsSize = upsertsOpt.get.size
+      val documentsSize = documents.size
+      if(upsertsSize != documentsSize) {
+        logger.warn(s"Number of documents $documentsSize is different from number of upserts $upsertsSize. " +
+          s"Only first ${Math.min(documentsSize, upsertsSize)} updates in the bulkUpdate request will be applied.")
+      }
       Bulk(documents.zip(upsertsOpt.getOrElse(documents)).map { case (document, upsert) =>
         BulkOperation(update, Some(index -> tpe), document, retryOnConflictOpt, Some(upsert))})
     }

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -148,9 +148,15 @@ class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[
   }
 
   // retryOnConflictOpt specifies how many times to retry before throwing version conflict exception.
-  // https://www.elastic.co/guide/en/elasticsearch/reference/2.3/docs-update.html#_parameters_2
-  def bulkUpdate(index: Index, tpe: Type, documents: Seq[Document], retryOnConflictOpt: Option[Int] = None): Future[Seq[BulkItem]] = {
-    val bulkOperation = Bulk(documents.map(BulkOperation(update, Some(index -> tpe), _, retryOnConflictOpt)))
+  // upsertOpt specifies the document to create in an update request when the document does not exist.
+  // https://www.elastic.co/guide/en/elasticsearch/reference/2.3/docs-update.html
+  def bulkUpdate(index: Index, tpe: Type, documents: Seq[Document], retryOnConflictOpt: Option[Int] = None, upsertsOpt: Option[Seq[Document]] = None): Future[Seq[BulkItem]] = {
+    val bulkOperation = if(upsertsOpt.isEmpty) {
+      Bulk(documents.map(BulkOperation(update, Some(index -> tpe), _, retryOnConflictOpt)))
+    } else {
+      Bulk(documents.zip(upsertsOpt.getOrElse(documents)).map { case (document, upsert) =>
+        BulkOperation(update, Some(index -> tpe), document, retryOnConflictOpt, Some(upsert))})
+    }
     bulkIndex(bulkOperation)
   }
   

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -148,21 +148,9 @@ class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[
   }
 
   // retryOnConflictOpt specifies how many times to retry before throwing version conflict exception.
-  // upsertOpt specifies the document to create in an update request when the document does not exist.
-  // https://www.elastic.co/guide/en/elasticsearch/reference/2.3/docs-update.html
-  def bulkUpdate(index: Index, tpe: Type, documents: Seq[Document], retryOnConflictOpt: Option[Int] = None, upsertsOpt: Option[Seq[Document]] = None): Future[Seq[BulkItem]] = {
-    val bulkOperation = if(upsertsOpt.isEmpty) {
-      Bulk(documents.map(BulkOperation(update, Some(index -> tpe), _, retryOnConflictOpt)))
-    } else {
-      val upsertsSize = upsertsOpt.get.size
-      val documentsSize = documents.size
-      if(upsertsSize != documentsSize) {
-        logger.warn(s"Number of documents $documentsSize is different from number of upserts $upsertsSize. " +
-          s"Only first ${Math.min(documentsSize, upsertsSize)} updates in the bulkUpdate request will be applied.")
-      }
-      Bulk(documents.zip(upsertsOpt.getOrElse(documents)).map { case (document, upsert) =>
-        BulkOperation(update, Some(index -> tpe), document, retryOnConflictOpt, Some(upsert))})
-    }
+  // https://www.elastic.co/guide/en/elasticsearch/reference/2.3/docs-update.html#_parameters_2
+  def bulkUpdate(index: Index, tpe: Type, documents: Seq[Document], retryOnConflictOpt: Option[Int] = None): Future[Seq[BulkItem]] = {
+    val bulkOperation = Bulk(documents.map(BulkOperation(update, Some(index -> tpe), _, retryOnConflictOpt)))
     bulkIndex(bulkOperation)
   }
   

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/IndexDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/IndexDsl.scala
@@ -60,11 +60,13 @@ trait IndexDsl extends DslCommons {
     def toJsonStr: String = {
       val (doc, retryOpt) = operation match {
         case `update` =>
-          if (upsertOpt.isEmpty) {
-            (Document(document.id, Map("doc"->document.data) ++ Map("detect_noop" -> true, "doc_as_upsert" -> true)), retryOnConflictOpt.map(n => Map("_retry_on_conflict" -> n)))
-          } else {
-            (Document(document.id, Map("doc"->document.data) ++ Map("detect_noop" -> true) ++ Map("upsert" -> upsertOpt.getOrElse(document).data)), retryOnConflictOpt.map(n => Map("_retry_on_conflict" -> n)))
+          val updateOps = upsertOpt match {
+            case Some(upsert) =>
+              Map("upsert" -> upsert.data)
+            case None =>
+              Map("doc_as_upsert" -> true)
           }
+          (Document(document.id, Map("doc"->document.data) ++ Map("detect_noop" -> true) ++ updateOps), retryOnConflictOpt.map(n => Map("_retry_on_conflict" -> n)))
         case _ => (document, None)
       }
 

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -376,22 +376,16 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
 
     "Support bulk partial document updates with whole document upserts" in {
       val docOrigin1 = Document("bulk_upsert_doc1", Map("text" -> "original", "foo" -> "bar"))
-      val docOrigin2 = Document("bulk_upsert_doc2", Map("text" -> "original", "foo" -> "bar"))
-      val docOrigin3 = Document("bulk_upsert_doc3", Map("text" -> "original", "foo" -> "bar"))
-      val docs = Seq(docOrigin1, docOrigin2, docOrigin3)
+      val docs = Seq(docOrigin1)
       indexDocs(docs)
 
       val docUpdate1 = Document("bulk_upsert_doc1", Map("text" -> "update"))
       val docUpdate2 = Document("bulk_upsert_doc2", Map("text" -> "update"))
-      val docUpdate3 = Document("bulk_upsert_doc3", Map("text" -> "update"))
-      val docUpdate4 = Document("bulk_upsert_doc4", Map("text" -> "update"))
-      val docsUpdate = Seq(docUpdate1, docUpdate2, docUpdate3, docUpdate4)
+      val docsUpdate = Seq(docUpdate1, docUpdate2)
 
       val docUpsert1 = Document("bulk_upsert_doc1", Map("text" -> "update", "notfoo" -> "notbar"))
-      val docUpsert2 = Document("bulk_upsert_doc2", Map("text" -> "update", "notfoo" -> "notbar"))
-      val docUpsert3 = Document("bulk_upsert_doc3", Map("text" -> "update", "notfoo" -> "notbar"))
-      val docUpsert4 = Document("bulk_upsert_doc4", Map("text" -> "update", "foo" -> "bar"))
-      val docsUpdsert = Seq(docUpdate1, docOrigin2, docOrigin3, docUpdate4)
+      val docUpsert2 = Document("bulk_upsert_doc2", Map("text" -> "update", "foo" -> "bar"))
+      val docsUpdsert = Seq(docUpsert1, docUpsert2)
 
       val updateFuture = restClient.bulkUpdate(index, tpe, docsUpdate, upsertsOpt=Some(docsUpdsert))
 
@@ -399,11 +393,9 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
 
       val resFut = restClient.query(index, tpe, new QueryRoot(TermQuery("text", "update")))
 
-      // doc 1, 2, 3 should do partial update, doc 4 should do whole doc upsert
+      // doc 1 should do partial update, doc 2 should do whole doc upsert
       whenReady(resFut) { res =>
         res.sourceAsMap should equal(Seq(
-          Map("text" -> "update"),
-          Map("text" -> "update", "foo"-> "bar"),
           Map("text" -> "update", "foo" -> "bar"),
           Map("text" -> "update", "foo" -> "bar")))
       }

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -374,6 +374,41 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       }
     }
 
+    "Support bulk partial document updates with whole document upserts" in {
+      val docOrigin1 = Document("bulk_upsert_doc1", Map("text" -> "original", "foo" -> "bar"))
+      val docOrigin2 = Document("bulk_upsert_doc2", Map("text" -> "original", "foo" -> "bar"))
+      val docOrigin3 = Document("bulk_upsert_doc3", Map("text" -> "original", "foo" -> "bar"))
+      val docs = Seq(docOrigin1, docOrigin2, docOrigin3)
+      indexDocs(docs)
+
+      val docUpdate1 = Document("bulk_upsert_doc1", Map("text" -> "update"))
+      val docUpdate2 = Document("bulk_upsert_doc2", Map("text" -> "update"))
+      val docUpdate3 = Document("bulk_upsert_doc3", Map("text" -> "update"))
+      val docUpdate4 = Document("bulk_upsert_doc4", Map("text" -> "update"))
+      val docsUpdate = Seq(docUpdate1, docUpdate2, docUpdate3, docUpdate4)
+
+      val docUpsert1 = Document("bulk_upsert_doc1", Map("text" -> "update", "notfoo" -> "notbar"))
+      val docUpsert2 = Document("bulk_upsert_doc2", Map("text" -> "update", "notfoo" -> "notbar"))
+      val docUpsert3 = Document("bulk_upsert_doc3", Map("text" -> "update", "notfoo" -> "notbar"))
+      val docUpsert4 = Document("bulk_upsert_doc4", Map("text" -> "update", "foo" -> "bar"))
+      val docsUpdsert = Seq(docUpdate1, docOrigin2, docOrigin3, docUpdate4)
+
+      val updateFuture = restClient.bulkUpdate(index, tpe, docsUpdate, upsertsOpt=Some(docsUpdsert))
+
+      whenReady(updateFuture) { _ => refresh() }
+
+      val resFut = restClient.query(index, tpe, new QueryRoot(TermQuery("text", "update")))
+
+      // doc 1, 2, 3 should do partial update, doc 4 should do whole doc upsert
+      whenReady(resFut) { res =>
+        res.sourceAsMap should equal(Seq(
+          Map("text" -> "update"),
+          Map("text" -> "update", "foo"-> "bar"),
+          Map("text" -> "update", "foo" -> "bar"),
+          Map("text" -> "update", "foo" -> "bar")))
+      }
+    }
+
     "Support case insensitive autocomplete" in {
 
       val basicFieldMapping = BasicFieldMapping(StringType, None, Some(analyzerName))

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -381,13 +381,14 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
 
       val docUpdate1 = Document("bulk_upsert_doc1", Map("text" -> "update"))
       val docUpdate2 = Document("bulk_upsert_doc2", Map("text" -> "update"))
-      val docsUpdate = Seq(docUpdate1, docUpdate2)
 
       val docUpsert1 = Document("bulk_upsert_doc1", Map("text" -> "update", "notfoo" -> "notbar"))
       val docUpsert2 = Document("bulk_upsert_doc2", Map("text" -> "update", "foo" -> "bar"))
-      val docsUpdsert = Seq(docUpsert1, docUpsert2)
 
-      val updateFuture = restClient.bulkUpdate(index, tpe, docsUpdate, upsertsOpt=Some(docsUpdsert))
+      val bulkOperation1 = BulkOperation(update, Some(index, tpe), docUpdate1, retryOnConflictOpt = Some(5), upsertOpt = Some(docUpsert1))
+      val bulkOperation2 = BulkOperation(update, Some(index, tpe), docUpdate2, retryOnConflictOpt = Some(5), upsertOpt = Some(docUpsert2))
+
+      val updateFuture = restClient.bulkIndex(Bulk(Seq(bulkOperation1, bulkOperation2)))
 
       whenReady(updateFuture) { _ => refresh() }
 


### PR DESCRIPTION
In the previous implementation of bulkUpdate request, 
```
def bulkUpdate(index: Index, tpe: Type, documents: Seq[Document], retryOnConflictOpt: Option[Int] = None)
```
`doc_as_upsert` is always true. The document we provide in the update request need to be the whole document. 

https://www.elastic.co/guide/en/elasticsearch/reference/2.3/docs-update.html

This PR adds an upsertOpt: Option[Document] = None option to the bulkUpdate request. 
- When upsertOpt = None, defaults to the old behavior
- When upsertOpt = Some(doc_as_upsert), doc provided is used for update/partial update, doc_as_upsert provided is used for index when a document does not already exists. 