### PR TITLE
Expose doc_as_upsert in bulk operaion api

### DIFF
--- a/elasticsearch-akka/src/main/scala/com/sumologic/elasticsearch/akkahelpers/BulkIndexerActor.scala
+++ b/elasticsearch-akka/src/main/scala/com/sumologic/elasticsearch/akkahelpers/BulkIndexerActor.scala
@@ -63,8 +63,8 @@ class BulkIndexerActor(restlasticSearchClient: RestlasticSearchClient, bulkConfi
       queue = OpWithTarget(BulkOperation(index, Some(indexName -> tpe), doc), sender(), sess) :: queue
       if (queueFull) flush()
 
-    case UpdateRequest(sess, index, tpe, doc, retryOnConflictOpt, upsertOpt) =>
-      queue = OpWithTarget(BulkOperation(update, Some(index -> tpe), doc, retryOnConflictOpt, upsertOpt), sender(), sess) :: queue
+    case UpdateRequest(sess, index, tpe, doc, retryOnConflictOpt, upsertOpt, docAsUpsertOpt) =>
+      queue = OpWithTarget(BulkOperation(update, Some(index -> tpe), doc, retryOnConflictOpt, upsertOpt, docAsUpsertOpt), sender(), sess) :: queue
       if (queueFull) flush()
 
     case ForceFlush => flush()
@@ -131,7 +131,7 @@ object BulkIndexerActor {
   // Messages
   case class CreateRequest(sessionId: BulkSession, index: Index, tpe: Type, doc: Document)
   case class IndexRequest(sessionId: BulkSession, index: Index, tpe: Type, doc: Document)
-  case class UpdateRequest(sessionId: BulkSession, index: Index, tpe: Type, doc: Document, retryOnConflictOpt: Option[Int] = None, upsertOpt: Option[Document] = None)
+  case class UpdateRequest(sessionId: BulkSession, index: Index, tpe: Type, doc: Document, retryOnConflictOpt: Option[Int] = None, upsertOpt: Option[Document] = None, docAsUpsertOpt: Option[Boolean] = None)
   case object ForceFlush
 
   // Replies

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/IndexDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/IndexDsl.scala
@@ -54,7 +54,7 @@ trait IndexDsl extends DslCommons {
   // When upsertOpt is specified, its content is used for upsert as described in
   // https://www.elastic.co/guide/en/elasticsearch/reference/2.3/docs-update.html
   // When upsertOpt is not given, document is used for upsert.
-  case class BulkOperation(operation: OperationType, location: Option[(Index, Type)], document: Document, retryOnConflictOpt: Option[Int] = None, upsertOpt: Option[Document] = None) extends EsOperation {
+  case class BulkOperation(operation: OperationType, location: Option[(Index, Type)], document: Document, retryOnConflictOpt: Option[Int] = None, upsertOpt: Option[Document] = None, docAsUpsertOpt: Option[Boolean] = None) extends EsOperation {
     import EsOperation.compactJson
     override def toJson: Map[String, Any] = throw new UnsupportedOperationException
     def toJsonStr: String = {
@@ -64,7 +64,7 @@ trait IndexDsl extends DslCommons {
             case Some(upsert) =>
               Map("upsert" -> upsert.data)
             case None =>
-              Map("doc_as_upsert" -> true)
+              Map("doc_as_upsert" -> docAsUpsertOpt.getOrElse(true))
           }
           (Document(document.id, Map("doc"->document.data) ++ Map("detect_noop" -> true) ++ updateOps), retryOnConflictOpt.map(n => Map("_retry_on_conflict" -> n)))
         case _ => (document, None)

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -402,6 +402,22 @@ class RestlasticSearchClientTest extends WordSpec with Matchers with ScalaFuture
       }
     }
 
+    "Return error when update a document that does not exist and doc as upsert is set to false" in {
+      val docNotExist = Document("doc_not_exist", Map("foo" -> "bar"))
+      val updateOperation = BulkOperation(update, Some(index, tpe), docNotExist, retryOnConflictOpt = Some(5), docAsUpsertOpt = Some(false))
+      val resultFuture = restClient.bulkIndex(Bulk(Seq(updateOperation)))
+      resultFuture.futureValue.head.status should be(404)
+      resultFuture.futureValue.head.success should be(false)
+    }
+
+    "Return success when update a document that does not exist and doc as upsert is set to true" in {
+      val docNotExist = Document("doc_not_exist", Map("foo" -> "bar"))
+      val updateOperation = BulkOperation(update, Some(index, tpe), docNotExist, retryOnConflictOpt = Some(5), docAsUpsertOpt = Some(true) )
+      val resultFuture = restClient.bulkIndex(Bulk(Seq(updateOperation)))
+      resultFuture.futureValue.head.status should be(201)
+      resultFuture.futureValue.head.success should be(true)
+    }
+
     "Support case insensitive autocomplete" in {
 
       val basicFieldMapping = BasicFieldMapping(StringType, None, Some(analyzerName))


### PR DESCRIPTION
doc_as_upsert is documented here https://www.elastic.co/guide/en/elasticsearch/reference/2.3/docs-update.html#_literal_doc_as_upsert_literal

Ideally we should make `BulkOperation` a trait, and have `BulkCreateOperation`, `BulkUpdateOperation`, `BulkDeleteOperation` etc.  Waiting for the 6.x branch cut to introducing this breaking change, issue https://github.com/SumoLogic/elasticsearch-client/issues/152. 

It is a small enough change, I am going to merge it now to block our development. Will be happy to incorporate any review feedbacks in a separate PR. 