### PR TITLE
Support NestedMapping and MultiFieldsMapping in Release 2.0.8.1

### DIFF
--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/MappingDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/MappingDsl.scala
@@ -142,9 +142,13 @@ trait MappingDsl extends DslCommons {
   val _ignoreAbove = "ignore_above"
   val _fieldIndexOpions = "index_options"
 
-  case class BasicFieldMapping(tpe: FieldType, index: Option[IndexType], analyzer: Option[Name],
-                               ignoreAbove: Option[Int] = None, search_analyzer: Option[Name]= None,
-                               indexOption: Option[IndexOption] = None)
+  case class BasicFieldMapping(tpe: FieldType,
+                               index: Option[IndexType],
+                               analyzer: Option[Name],
+                               ignoreAbove: Option[Int] = None,
+                               search_analyzer: Option[Name]= None,
+                               indexOption: Option[IndexOption] = None,
+                               fieldsOption: Option[FieldsMapping] = None)
     extends FieldMapping {
 
     override def toJson: Map[String, Any] = Map(
@@ -153,11 +157,21 @@ trait MappingDsl extends DslCommons {
       analyzer.map(_analyzer -> _.name) ++
       search_analyzer.map(_searchAnalyzer -> _.name) ++
       indexOption.map(_fieldIndexOpions -> _.option)
-      ignoreAbove.map(_ignoreAbove -> _).toList.toMap
+      ignoreAbove.map(_ignoreAbove -> _) ++ fieldsOption
+  }
+
+  case class FieldsMapping(fields: Map[String, FieldMapping]) extends FieldMapping {
+    val _fields = "fields"
+    override def toJson: Map[String, Any] = Map(_fields -> fields.mapValues(_.toJson))
   }
 
   case class BasicObjectMapping(fields: Map[String, FieldMapping]) extends FieldMapping {
     override def toJson: Map[String, Any] = Map(_properties -> fields.mapValues(_.toJson))
+  }
+
+  case class NestedObjectMapping(fields: Map[String, FieldMapping]) extends FieldMapping {
+    val _nested = "nested"
+    override def toJson: Map[String, Any] = Map(_type -> _nested, _properties -> fields.mapValues(_.toJson))
   }
 
   trait Completion {

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/MappingDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/MappingDsl.scala
@@ -156,8 +156,9 @@ trait MappingDsl extends DslCommons {
       index.map(_index -> _.rep) ++
       analyzer.map(_analyzer -> _.name) ++
       search_analyzer.map(_searchAnalyzer -> _.name) ++
-      indexOption.map(_fieldIndexOpions -> _.option)
-      ignoreAbove.map(_ignoreAbove -> _) ++ fieldsOption
+      indexOption.map(_fieldIndexOpions -> _.option) ++
+      ignoreAbove.map(_ignoreAbove -> _) ++
+      fieldsOption.map(_.toJson).getOrElse(Map[String, Any]())
   }
 
   case class FieldsMapping(fields: Map[String, FieldMapping]) extends FieldMapping {


### PR DESCRIPTION
We haven't moved elastic-client to 6.x in metrics. Plan is to do that next quarter. Meanwhile, we will need to support nested mapping and multi-fields mapping. I am adding this change to this branch only atm. I will create a 2.0.9 branch for publishing after all functionalities has been included.

I am also adding a issue https://github.com/SumoLogic/elasticsearch-client/issues/164 to cherry-pick changes here to the latest master. 