### PR TITLE
MET-0 Solve fixed http timeout problem

### DIFF
--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -297,7 +297,8 @@ class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[
 
     logger.debug(f"Got Rs request: $request (op was $op)")
 
-    val responseFuture: Future[HttpResponse] = (IO(Http) ? request).mapTo[HttpResponse]
+
+    val responseFuture: Future[HttpResponse] = (IO(Http) ? request)(timeout).mapTo[HttpResponse]
 
     responseFuture.map { response =>
       logger.debug(f"Got Es response: $response")


### PR DESCRIPTION
in `runRawEsRequest ` we use default timeout when creating aHTTP request to elasticsearch.
Then even though we return a `Future[RawJsonResponse]`, the maximum timeout is fixed to 20s.
User have no way decide to wait longer than 20 s for a whole request to complete.

This PR fixes this problem by passing timeout explicitly.

