### PR TITLE
Reindexing improvements

### DIFF
--- a/elasticsearch-akka/src/test/scala/com/sumologic/elasticsearch/akkahelpers/ScanAndScrollSourceTest.scala
+++ b/elasticsearch-akka/src/test/scala/com/sumologic/elasticsearch/akkahelpers/ScanAndScrollSourceTest.scala
@@ -70,7 +70,8 @@ class MockScrollClient(results: List[SearchResponse]) extends ScrollClient {
   var resultsQueue = results
   override val indexExecutionCtx: ExecutionContext = ExecutionContext.Implicits.global
   override def startScrollRequest(index: Dsl.Index, tpe: Dsl.Type, query: Dsl.QueryRoot,
-                                  resultWindowOpt: Option[String] = None, fromOpt: Option[Int] = None, sizeOpt: Option[Int] = None): Future[(ScrollId, SearchResponse)] = {
+                                  resultWindowOpt: Option[String] = None, fromOpt: Option[Int] = None,
+                                  sizeOpt: Option[Int] = None, preference: Option[String] = None): Future[(ScrollId, SearchResponse)] = {
     if (!started) {
       started = true
       processRequest()

--- a/elasticsearch-core/pom.xml
+++ b/elasticsearch-core/pom.xml
@@ -38,7 +38,7 @@
 
     <dependency>
       <groupId>org.json4s</groupId>
-      <artifactId>json4s-native_${scala.version.major}</artifactId>
+      <artifactId>json4s-jackson_${scala.version.major}</artifactId>
       <version>3.3.0</version>
     </dependency>
 

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -39,7 +39,13 @@ trait ScrollClient {
   // Scroll requests have optimizations that make them faster when the sort order is _doc.
   // Put sort by _doc in query as described in the the following document
   // https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html
-  def startScrollRequest(index: Index, tpe: Type, query: QueryRoot, resultWindowOpt: Option[String] = None, fromOpt: Option[Int] = None, sizeOpt: Option[Int] = None): Future[(ScrollId, SearchResponse)]
+  def startScrollRequest(index: Index,
+                         tpe: Type,
+                         query: QueryRoot,
+                         resultWindowOpt: Option[String] = None,
+                         fromOpt: Option[Int] = None,
+                         sizeOpt: Option[Int] = None,
+                         preference: Option[String] = None): Future[(ScrollId, SearchResponse)]
 
   def scroll(scrollId: ScrollId, resultWindowOpt: Option[String] = None): Future[(ScrollId, SearchResponse)]
 }

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -22,7 +22,7 @@ import com.sumologic.elasticsearch.restlastic.RestlasticSearchClient.ReturnTypes
 import com.sumologic.elasticsearch.restlastic.dsl.{Dsl, EsVersion}
 import org.json4s.FieldSerializer.{renameFrom, renameTo}
 import org.json4s._
-import org.json4s.native.JsonMethods._
+import org.json4s.jackson.JsonMethods._
 import spray.http.HttpMethods._
 import spray.http.Uri.{Query => UriQuery}
 import spray.http._

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient2.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient2.scala
@@ -204,9 +204,18 @@ class RestlasticSearchClient2(endpointProvider: EndpointProvider, signer: Option
   // Scroll requests have optimizations that make them faster when the sort order is _doc.
   // Put sort by _doc in query as described in the the following document
   // https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html
-  def startScrollRequest(index: Index, tpe: Type, query: QueryRoot, resultWindowOpt: Option[String] = None, fromOpt: Option[Int] = None, sizeOpt: Option[Int] = None): Future[(ScrollId, SearchResponse)] = {
+  def startScrollRequest(index: Index,
+                         tpe: Type,
+                         query: QueryRoot,
+                         resultWindowOpt: Option[String] = None,
+                         fromOpt: Option[Int] = None,
+                         sizeOpt: Option[Int] = None,
+                         preference: Option[String] = None): Future[(ScrollId, SearchResponse)] = {
     implicit val ec = searchExecutionCtx
-    val params = Map("scroll" -> resultWindowOpt.getOrElse(defaultResultWindow)) ++ fromOpt.map("from" -> _.toString) ++ sizeOpt.map("size" -> _.toString)
+    val params = Map("scroll" -> resultWindowOpt.getOrElse(defaultResultWindow)) ++
+      fromOpt.map("from" -> _.toString) ++
+      sizeOpt.map("size" -> _.toString) ++
+      preference.map("preference" -> _)
     runEsCommand(query, s"/${index.name}/${tpe.name}/_search", query = UriQuery(params)).map { resp =>
       val sr = resp.mappedTo[SearchResponseWithScrollId]
       (ScrollId(sr._scroll_id), SearchResponse(RawSearchResponse(sr.hits), resp.jsonStr))

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient6.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient6.scala
@@ -216,9 +216,17 @@ class RestlasticSearchClient6(endpointProvider: EndpointProvider, signer: Option
   // Scroll requests have optimizations that make them faster when the sort order is _doc.
   // Put sort by _doc in query as described in the the following document
   // https://www.elastic.co/guide/en/elasticsearch/reference/current/search-request-scroll.html
-  def startScrollRequest(index: Index, tpe: Type, query: QueryRoot, resultWindowOpt: Option[String] = None, fromOpt: Option[Int] = None, sizeOpt: Option[Int] = None): Future[(ScrollId, SearchResponse)] = {
+  def startScrollRequest(index: Index,
+                         tpe: Type,
+                         query: QueryRoot,
+                         resultWindowOpt: Option[String] = None,
+                         fromOpt: Option[Int] = None,
+                         sizeOpt: Option[Int] = None,
+                         preference: Option[String] = None): Future[(ScrollId, SearchResponse)] = {
     implicit val ec = searchExecutionCtx
-    val params = Map("scroll" -> resultWindowOpt.getOrElse(defaultResultWindow)) ++ sizeOpt.map("size" -> _.toString)
+    val params = Map("scroll" -> resultWindowOpt.getOrElse(defaultResultWindow)) ++
+      sizeOpt.map("size" -> _.toString) ++
+      preference.map("preference" -> _)
     runEsCommand(query, s"/${index.name}/${tpe.name}/_search", query = UriQuery(params)).map { resp =>
       val sr = resp.mappedTo[SearchResponseWithScrollId]
       (ScrollId(sr._scroll_id), SearchResponse(RawSearchResponse(sr.hits), resp.jsonStr))

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/DslCommons.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/DslCommons.scala
@@ -20,7 +20,7 @@ package com.sumologic.elasticsearch.restlastic.dsl
 
 import org.json4s.Extraction._
 import org.json4s._
-import org.json4s.native.JsonMethods._
+import org.json4s.jackson.JsonMethods._
 
 trait DslCommons {
 

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/IndexDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/IndexDsl.scala
@@ -18,6 +18,8 @@
  */
 package com.sumologic.elasticsearch.restlastic.dsl
 
+import scala.collection.concurrent.TrieMap
+
 trait IndexDsl extends DslCommons {
 
   case class CreateIndex(settings: Option[IndexSetting] = None) extends RootObject {
@@ -54,9 +56,13 @@ trait IndexDsl extends DslCommons {
   }
 
   case class Bulk(operations: Seq[BulkOperation]) extends EsOperation with RootObject {
+    private val jsonStrCache = TrieMap.empty[EsVersion, String]
+
     override def toJson(version: EsVersion): Map[String, Any] = throw new UnsupportedOperationException
 
-    override def toJsonStr(version: EsVersion): String = operations.map(_.toJsonStr(version)).mkString("", "\n", "\n")
+    override def toJsonStr(version: EsVersion): String = {
+      jsonStrCache.getOrElseUpdate(version, operations.map(_.toJsonStr(version)).mkString("", "\n", "\n"))
+    }
   }
 
   // When upsertOpt is specified, its content is used for upsert as described in

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient6Test.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient6Test.scala
@@ -32,7 +32,7 @@ class RestlasticSearchClient6Test extends WordSpec with Matchers with BeforeAndA
       IndexName,
       createIndex(),
       TextType,
-      BasicFieldMapping(KeywordType, None, None, ignoreAbove = None, None))
+      BasicFieldMapping(KeywordType, None, None))
   }
 }
 

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -234,11 +234,6 @@ trait RestlasticSearchClientTest {
       val docUpdate2 = Document("doc", Map("text" -> "retry on version conflict 2"))
       val docUpdate3 = Document("doc", Map("text" -> "retry on version conflict 3"))
 
-      val bulkUpdateFuture = (1 to 5).map { _ =>
-        restClient.bulkUpdate(index, tpe, Seq(docUpdate1, docUpdate2, docUpdate3))
-      }
-      Future.sequence(bulkUpdateFuture).futureValue.toString().contains("version conflict") should be(true)
-
       val bulkUpdateFutureWithRetry = (1 to 5).map { _ =>
         restClient.bulkUpdate(index, tpe, Seq(docUpdate1, docUpdate2, docUpdate3), retryOnConflictOpt = Some(100))
       }

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -22,7 +22,7 @@ import com.sumologic.elasticsearch.restlastic.RestlasticSearchClient.ReturnTypes
 import com.sumologic.elasticsearch.restlastic.dsl.{Dsl, V2, V6}
 import com.sumologic.elasticsearch.restlastic.dsl.Dsl._
 import org.json4s.DefaultFormats
-import org.json4s.native.JsonMethods.parse
+import org.json4s.jackson.JsonMethods.parse
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Seconds, Span}
 import org.scalatest.{Matchers, WordSpec}


### PR DESCRIPTION
Two things:
1. `preference` support in scan request
2. `Bulk.toJsonStr` optimized - we now use json4s-jackson and cache json string