### PR TITLE
MET-8230 querying multiple indices

### DIFF
--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -280,6 +280,11 @@ abstract class RestlasticSearchClient(endpointProvider: EndpointProvider, signer
     runEsCommand(EmptyObject, s"/${index.name}/_refresh")
   }
 
+  def refresh(indices: Seq[Index]): Future[RawJsonResponse] = {
+    implicit val ec = indexExecutionCtx
+    runEsCommand(EmptyObject, s"/${indices.map(i => i.name).mkString(",")}}/_refresh")
+  }
+
   def version: EsVersion
 
   protected def runEsCommand(op: RootObject,

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -170,6 +170,8 @@ abstract class RestlasticSearchClient(endpointProvider: EndpointProvider, signer
 
   def deleteByQuery(index: Index, tpe: Type, query: QueryRoot, waitForCompletion: Boolean): Future[RawJsonResponse]
 
+  def deleteByQuery(indices: Seq[Index], tpe: Type, query: QueryRoot, waitForCompletion: Boolean): Future[RawJsonResponse]
+
   def documentExistsById(index: Index, tpe: Type, id: String): Future[Boolean] = {
     implicit val ec = indexExecutionCtx
     runEsCommand(NoOp, s"/${index.name}/${tpe.name}/$id", HEAD).map(_ => true).recover {
@@ -240,7 +242,6 @@ abstract class RestlasticSearchClient(endpointProvider: EndpointProvider, signer
 
   def deleteDocuments(index: Index, tpe: Type, deleteQuery: QueryRoot, pluginEnabled: Boolean = false): Future[Map[Index, DeleteResponse]] = {
     def firstScroll(scId: ScrollId) = startScrollRequest(index, tpe, deleteQuery)
-
     scrollDelete(index, tpe, ScrollId(""), Map.empty[Index, DeleteResponse], firstScroll)
   }
 

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -109,11 +109,11 @@ abstract class RestlasticSearchClient(endpointProvider: EndpointProvider, signer
   }
 
   def queryIndices(indices: Seq[Index],
-            tpe: Type,
-            query: RootObject,
-            rawJsonStr: Boolean = true,
-            uriQuery: UriQuery = UriQuery.Empty,
-            profile: Boolean = false): Future[SearchResponse] = {
+                   tpe: Type,
+                   query: RootObject,
+                   rawJsonStr: Boolean = true,
+                   uriQuery: UriQuery = UriQuery.Empty,
+                   profile: Boolean = false): Future[SearchResponse] = {
     implicit val ec = searchExecutionCtx
     val endpoint = s"/${indices.map(i => i.name).mkString(",")}/${tpe.name}/_search"
     runEsCommand(query, endpoint, query = uriQuery, profile = profile).map { rawJson =>

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -108,7 +108,7 @@ abstract class RestlasticSearchClient(endpointProvider: EndpointProvider, signer
     }
   }
 
-  def queryIndices(indices: List[Index],
+  def queryIndices(indices: Seq[Index],
             tpe: Type,
             query: RootObject,
             rawJsonStr: Boolean = true,

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -108,6 +108,20 @@ abstract class RestlasticSearchClient(endpointProvider: EndpointProvider, signer
     }
   }
 
+  def queryIndices(indices: List[Index],
+            tpe: Type,
+            query: RootObject,
+            rawJsonStr: Boolean = true,
+            uriQuery: UriQuery = UriQuery.Empty,
+            profile: Boolean = false): Future[SearchResponse] = {
+    implicit val ec = searchExecutionCtx
+    val endpoint = s"/${indices.map(i => i.name).mkString(",")}/${tpe.name}/_search"
+    runEsCommand(query, endpoint, query = uriQuery, profile = profile).map { rawJson =>
+      val jsonStr = if(rawJsonStr) rawJson.jsonStr else ""
+      SearchResponse(rawJson.mappedTo[RawSearchResponse], jsonStr)
+    }
+  }
+
   def bucketNestedAggregation(index: Index, tpe: Type, query: AggregationQuery): Future[BucketNested] = {
     implicit val ec = searchExecutionCtx
     runEsCommand(query, s"/${index.name}/${tpe.name}/_search").map { rawJson =>

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -152,6 +152,12 @@ abstract class RestlasticSearchClient(endpointProvider: EndpointProvider, signer
     fut.map(_.mappedTo[CountResponse].count)
   }
 
+  def count(indices: Seq[Index], tpe: Type, query: QueryRoot): Future[Int] = {
+    implicit val ec = searchExecutionCtx
+    val fut = runEsCommand(query, s"/${indices.map(i => i.name).mkString(",")}/${tpe.name}/_count")
+    fut.map(_.mappedTo[CountResponse].count)
+  }
+
   def index(index: Index, tpe: Type, doc: Document): Future[IndexResponse] = {
     implicit val ec = indexExecutionCtx
     runEsCommand(doc, s"/${index.name}/${tpe.name}/${doc.id}").map(_.mappedTo[IndexResponse])

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient2.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient2.scala
@@ -40,6 +40,13 @@ class RestlasticSearchClient2(endpointProvider: EndpointProvider, signer: Option
     deleteDocuments(index, tpe, deleteQuery).map(resp => RawJsonResponse(resp.toString()))
   }
 
+  def deleteByQuery(indices: Seq[Index], tpe: Type, deleteQuery: QueryRoot, waitForCompletion: Boolean): Future[RawJsonResponse] = {
+    implicit val ec = indexExecutionCtx
+
+    Future.reduce(indices.map(i => deleteDocuments(i, tpe, deleteQuery)))(_ ++ _).map(
+      resp => RawJsonResponse(resp.toString()))
+  }
+
   def createIndex(index: Index, settings: Option[IndexSetting] = None): Future[RawJsonResponse] = {
     implicit val ec = indexExecutionCtx
     runEsCommand(CreateIndex(settings), s"/${index.name}").recover {

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient6.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient6.scala
@@ -53,6 +53,13 @@ class RestlasticSearchClient6(endpointProvider: EndpointProvider, signer: Option
     runEsCommand(deleteQuery, s"/${index.name}/${tpe.name}/_delete_by_query", query = uriQuery, method = POST)
   }
 
+  def deleteByQuery(indices: Seq[Index], tpe: Type, deleteQuery: QueryRoot, waitForCompletion: Boolean): Future[RawJsonResponse] = {
+    implicit val ec = indexExecutionCtx
+
+    val uriQuery = UriQuery("wait_for_completion" -> waitForCompletion.toString)
+    runEsCommand(deleteQuery, s"/${indices.map(i => i.name).mkString(",")}/${tpe.name}/_delete_by_query", query = uriQuery, method = POST)
+  }
+
   def createIndex(index: Index, settings: Option[IndexSetting] = None): Future[RawJsonResponse] = {
     implicit val ec = indexExecutionCtx
     runEsCommand(CreateIndex(settings), s"/${index.name}", PUT).recover {

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/ElasticsearchIntegrationTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/ElasticsearchIntegrationTest.scala
@@ -41,10 +41,11 @@ trait ElasticsearchIntegrationTest extends BeforeAndAfterAll with ScalaFutures {
 
   def restClient: RestlasticSearchClient
 
-  val IndexName = s"$indexPrefix-${Random.nextLong()}"
+  val IndexName = s"$indexPrefix-${math.abs(Random.nextLong())}"
 
-  protected def createIndex(): Index = {
-    val index = dsl.Dsl.Index(IndexName)
+  protected def createIndices(cnt: Int = 1): IndexedSeq[Index] = {
+    (1 to cnt).map(idx => {
+    val index = dsl.Dsl.Index(s"${IndexName}-${idx}")
     val analyzerName = Name("keyword_lowercase")
     val lowercaseAnalyzer = Analyzer(analyzerName, Keyword, Lowercase)
     val notAnalyzed = Analyzer(Name("not_analyzed"), Keyword)
@@ -56,6 +57,8 @@ trait ElasticsearchIntegrationTest extends BeforeAndAfterAll with ScalaFutures {
     val indexFut = restClient.createIndex(index, Some(indexSetting))
     indexFut.futureValue
     index
+  }
+    )
   }
 
   override def beforeAll(): Unit = {

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/ElasticsearchIntegrationTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/ElasticsearchIntegrationTest.scala
@@ -45,20 +45,19 @@ trait ElasticsearchIntegrationTest extends BeforeAndAfterAll with ScalaFutures {
 
   protected def createIndices(cnt: Int = 1): IndexedSeq[Index] = {
     (1 to cnt).map(idx => {
-    val index = dsl.Dsl.Index(s"${IndexName}-${idx}")
-    val analyzerName = Name("keyword_lowercase")
-    val lowercaseAnalyzer = Analyzer(analyzerName, Keyword, Lowercase)
-    val notAnalyzed = Analyzer(Name("not_analyzed"), Keyword)
-    val analyzers = Analyzers(
-      AnalyzerArray(lowercaseAnalyzer, notAnalyzed),
-      FilterArray(),
-      NormalizerArray(Normalizer(Name("lowercase"), Lowercase)))
-    val indexSetting = IndexSetting(12, 1, analyzers, 30)
-    val indexFut = restClient.createIndex(index, Some(indexSetting))
-    indexFut.futureValue
-    index
-  }
-    )
+      val index = dsl.Dsl.Index(s"${IndexName}-${idx}")
+      val analyzerName = Name("keyword_lowercase")
+      val lowercaseAnalyzer = Analyzer(analyzerName, Keyword, Lowercase)
+      val notAnalyzed = Analyzer(Name("not_analyzed"), Keyword)
+      val analyzers = Analyzers(
+        AnalyzerArray(lowercaseAnalyzer, notAnalyzed),
+        FilterArray(),
+        NormalizerArray(Normalizer(Name("lowercase"), Lowercase)))
+      val indexSetting = IndexSetting(12, 1, analyzers, 30)
+      val indexFut = restClient.createIndex(index, Some(indexSetting))
+      indexFut.futureValue
+      index
+    })
   }
 
   override def beforeAll(): Unit = {

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient2Test.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient2Test.scala
@@ -25,12 +25,13 @@ class RestlasticSearchClient2Test extends WordSpec with Matchers with BeforeAndA
     with ElasticsearchIntegrationTest with OneInstancePerTest with RestlasticSearchClientTest {
 
   override val restClient = RestlasticSearchClient2Test.restClient
+  val indices = createIndices(3)
 
   "RestlasticSearchClient2" should {
     behave like restlasticClient(
       restClient,
       IndexName,
-      createIndex(),
+      indices,
       StringType,
       BasicFieldMapping(StringType, None, Some(Name("not_analyzed")), ignoreAbove = None, None))
   }

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient6Test.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient6Test.scala
@@ -29,13 +29,14 @@ class RestlasticSearchClient6Test extends WordSpec with Matchers with BeforeAndA
 
   val basicKeywordFieldMapping = BasicFieldMapping(KeywordType, None, None)
 
-  val index = createIndex()
+  val indices = createIndices(3)
+  val index = indices.apply(0)
 
   "RestlasticSearchClient6" should {
     behave like restlasticClient(
       restClient,
       IndexName,
-      index,
+      indices,
       TextType,
       basicKeywordFieldMapping)
 

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -43,24 +43,29 @@ trait RestlasticSearchClientTest {
 
   def restlasticClient(restClient: => RestlasticSearchClient,
                        indexName: String,
-                       index: Dsl.Index,
+                       indices: IndexedSeq[Dsl.Index],
                        textType: FieldType,
                        basicKeywordFieldMapping: BasicFieldMapping): Unit = {
     val keywordType = basicKeywordFieldMapping.tpe
     val analyzerName = Name("keyword_lowercase")
     val basicTextFieldMapping = BasicFieldMapping(textType, None, Some(analyzerName), ignoreAbove = None, Some(analyzerName))
     val tpe = Type("foo")
+    val index = indices.apply(0)
 
     def refreshWithClient(): Unit = {
-      Await.result(restClient.refresh(index), 2.seconds)
+      indices.foreach { index =>
+        Await.result(restClient.refresh(index), 2.seconds)
+      }
     }
 
     def refresh(): Unit = {
-      restClient.refresh(index).futureValue(PatienceConfig(scaled(Span(1500, Millis)), scaled(Span(15, Millis))))
+      indices.foreach { index =>
+        restClient.refresh(index).futureValue(PatienceConfig(scaled(Span(1500, Millis)), scaled(Span(15, Millis))))
+      }
     }
 
-    def indexDocs(docs: Seq[Document]): Unit = {
-      val bulkIndexFuture = restClient.bulkIndex(index, tpe, docs)
+    def indexDocs(docs: Seq[Document], toIndex: Index = index): Unit = {
+      val bulkIndexFuture = restClient.bulkIndex(toIndex, tpe, docs)
       whenReady(bulkIndexFuture) { _ => refresh() }
     }
 
@@ -1294,6 +1299,25 @@ trait RestlasticSearchClientTest {
         res.sourceAsMap.toList should be(List(Map("animal" -> "wombat")))
         res.rawSearchResponse.profile should not be empty
         res.rawSearchResponse.profile should contain key "shards"
+      }
+    }
+
+    "be able to query three indices" in {
+      val index0 = indices.apply(0)
+      val index1 = indices.apply(1)
+      val index2 = indices.apply(2)
+      indexDocs(Seq(Document("doc1", Map("text" -> "lokomotywa"))), index0)
+      indexDocs(Seq(Document("doc1", Map("text" -> "stoi na stacji lokomotywa"))), index1)
+      indexDocs(Seq(Document("doc1", Map("text" -> "lokomotywa stoi na stacji"))), index2)
+      val resFut = restClient.queryIndices(List(index0, index1, index2), tpe, new QueryRoot(TermQuery("text", "lokomotywa"), timeoutOpt = Some(5000)))
+
+      whenReady(resFut) { res =>
+        println(res)
+        println(res.sourceAsMap.toList)
+        res.sourceAsMap.toList should be(
+          List(Map("text" -> "lokomotywa"),
+            Map("text" -> "stoi na stacji lokomotywa"),
+            Map("text" -> "lokomotywa stoi na stacji")))
       }
     }
   }

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -1320,6 +1320,26 @@ trait RestlasticSearchClientTest {
             Map("text" -> "lokomotywa stoi na stacji")))
       }
     }
+
+    "support the count API for many indices" in {
+      0 to 2 foreach { i =>
+        val docFutures = (1 to 7).map { n =>
+          Document(s"doc-$n", Map("ct" -> "ct", "id" -> n))
+        }.map { doc =>
+          restClient.index(indices.apply(i), tpe, doc)
+        }
+
+        val docs = Future.sequence(docFutures)
+        whenReady(docs) { _ =>
+          refresh()
+        }
+      }
+
+      val ctFut = restClient.count(indices, tpe, new QueryRoot(TermQuery("ct", "ct")))
+      whenReady(ctFut) { ct =>
+        ct should be(21)
+      }
+    }
   }
 }
 

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -1312,8 +1312,6 @@ trait RestlasticSearchClientTest {
       val resFut = restClient.queryIndices(List(index0, index1, index2), tpe, new QueryRoot(TermQuery("text", "lokomotywa"), timeoutOpt = Some(5000)))
 
       whenReady(resFut) { res =>
-        println(res)
-        println(res.sourceAsMap.toList)
         res.sourceAsMap.toList should be(
           List(Map("text" -> "lokomotywa"),
             Map("text" -> "stoi na stacji lokomotywa"),


### PR DESCRIPTION
Querying multiple indices. Same interface as for one index, but with `List[Index]` instead of `Index`.