### PR TITLE
Bump up the spray timeout to 60s

### DIFF
--- a/elasticsearch-core/src/main/resources/application.conf
+++ b/elasticsearch-core/src/main/resources/application.conf
@@ -1,0 +1,9 @@
+spray.can {
+  server {
+    request-timeout = 60 s
+  }
+
+  client {
+    request-timeout = 60 s
+  }
+}


### PR DESCRIPTION
The heavy delete by query requests (in wait for completion mode) can take > 20s. 
Bumping the spray limit from 20s to 60s. 
NOTE: It's http limit, not ES limit.