### PR TITLE
Replace slow HexOf in AWS signer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,11 @@
 language: java
+dist: trusty
+jdk:
+  - oraclejdk8
+addons:
+  apt:
+    packages:
+      - oracle-java8-installer
 before_install:
   - curl -O https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-6.3.0.tar.gz && tar -xzf elasticsearch-6.3.0.tar.gz
   - elasticsearch-6.3.0/bin/elasticsearch -Ecluster.name=es-63 -Ehttp.port=9800 > /dev/null 2> /dev/null &

--- a/elasticsearch-aws/src/main/scala/com/sumologic/elasticsearch/util/AwsRequestSigner.scala
+++ b/elasticsearch-aws/src/main/scala/com/sumologic/elasticsearch/util/AwsRequestSigner.scala
@@ -30,6 +30,7 @@ import spray.http.HttpRequest
 import com.amazonaws.auth.{AWSCredentials, AWSCredentialsProvider, AWSSessionCredentials}
 import com.amazonaws.internal.StaticCredentialsProvider
 import com.sumologic.elasticsearch.restlastic.RequestSigner
+import org.apache.commons.codec.binary.Hex
 
 /**
  * Sign AWS requests following the instructions at http://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html
@@ -191,5 +192,5 @@ class AwsRequestSigner(awsCredentialsProvider: AWSCredentialsProvider, region: S
     mac.doFinal(data.getBytes("UTF8"))
   }
 
-  private def hexOf(buf: Array[Byte]) = buf.map("%02X" format _).mkString.toLowerCase
+  private def hexOf(buf: Array[Byte]): String = Hex.encodeHexString(buf)
 }


### PR DESCRIPTION
Using https://github.com/szymonm/scala-benchmarking:

Before:
```
Benchmark        Mode  Cnt     Score    Error  Units
HexTest.ingest  thrpt   20  1461.657 ± 34.452  ops/s
```
After:
```
Benchmark        Mode  Cnt       Score       Error  Units
HexTest.ingest  thrpt   20  457745.938 ± 15106.433  ops/s
```