### PR TITLE
Support for max_result_window index setting

### DIFF
--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/IndexDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/IndexDsl.scala
@@ -100,7 +100,8 @@ trait IndexDsl extends DslCommons {
                           numberOfReplicas: Int,
                           analyzerMapping: Analysis,
                           refreshInterval: Int = 1,
-                          preload: Seq[String] = Seq.empty[String])
+                          preload: Seq[String] = Seq.empty[String],
+                          maxResultWindow: Int = 10000)
       extends EsOperation {
 
     val _shards = "number_of_shards"
@@ -108,13 +109,15 @@ trait IndexDsl extends DslCommons {
     val _analysis = "analysis"
     val _interval = "refresh_interval"
     val _preload = "index.store.preload"
+    val _maxResultWindow = "max_result_window"
 
     override def toJson(version: EsVersion): Map[String, Any] = {
       Map(
         _shards -> numberOfShards,
         _replicas -> numberOfReplicas,
         _analysis -> analyzerMapping.toJson(version),
-        _interval -> s"${refreshInterval}s") ++
+        _interval -> s"${refreshInterval}s",
+        _maxResultWindow -> maxResultWindow) ++
         (if (preload.isEmpty) Map.empty[String, Any] else Map(_preload -> preload))
     }
   }


### PR DESCRIPTION
This PR adds support for `max_result_window` index setting. The default setting is 10000 which is compatible with Elasticsearch's default.

The `max_result_window` is first mentioned in ES docs for version 2.1:
https://www.elastic.co/guide/en/elasticsearch/reference/2.1/index-modules.html

I think it's okay to support only 2.1-2.4 from 2.x branch. If you feel it'd be better to support 2.0 as well, I can change the `max_result_window` to be an optional argument. 