### PR TITLE
Updating json4s to the latest version

### DIFF
--- a/elasticsearch-core/pom.xml
+++ b/elasticsearch-core/pom.xml
@@ -25,7 +25,7 @@
     <dependency>
       <groupId>org.json4s</groupId>
       <artifactId>json4s-jackson_${scala.version.major}</artifactId>
-      <version>3.4.2</version>
+      <version>3.6.7</version>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Old (current) version of json4s has a dependency on vulnerable jackson version.