### PR TITLE
Scala 2.12 + 2.11 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+- Support for both Scala 2.11 and 2.12
+
+### Changed
+- Migrated from Spray to Akka HTTP
+
 ## [7.0.0-M19] - 2019-11-22
 
 ### Added

--- a/build.gradle
+++ b/build.gradle
@@ -151,7 +151,8 @@ project(':elasticsearch-core') {
         compile "org.json4s:json4s-jackson_${scalaMajorVersion}:${json4sVersion}"
         compile "org.slf4j:slf4j-api:${slf4jVersion}"
         compile "com.typesafe.akka:akka-actor_${scalaMajorVersion}:${akkaVersion}"
-        compile "io.spray:spray-can_${scalaMajorVersion}:${sprayVersion}"
+        compile "com.typesafe.akka:akka-http_${scalaMajorVersion}:${akkaHttpVersion}"
+        compile "com.typesafe.akka:akka-stream_${scalaMajorVersion}:${akkaVersion}"
 
         testCompile "org.apache.lucene:lucene-core:${luceneVersion}"
         testCompile "org.apache.lucene:lucene-analyzers-common:${luceneVersion}"
@@ -175,7 +176,8 @@ project(':elasticsearch-aws') {
         compile project(':elasticsearch-core')
         compile "com.amazonaws:aws-java-sdk-core:${awsJavaSdkVersion}"
         compile "org.slf4j:slf4j-api:${slf4jVersion}"
-        compile "io.spray:spray-can_${scalaMajorVersion}:${sprayVersion}"
+        compile "com.typesafe.akka:akka-http_${scalaMajorVersion}:${akkaHttpVersion}"
+        compile "com.typesafe.akka:akka-stream_${scalaMajorVersion}:${akkaVersion}"
         compile "com.typesafe.akka:akka-actor_${scalaMajorVersion}:${akkaVersion}"
     }
 }

--- a/elasticsearch-aws/src/test/scala/com/sumologic/elasticsearch/util/AwsRequestSignerTest.scala
+++ b/elasticsearch-aws/src/test/scala/com/sumologic/elasticsearch/util/AwsRequestSignerTest.scala
@@ -18,15 +18,14 @@
  */
 package com.sumologic.elasticsearch.util
 
+import akka.http.scaladsl.model.headers.{Host, RawHeader}
+import akka.http.scaladsl.model.{HttpEntity, HttpMethods, HttpRequest, Uri}
 import com.amazonaws.auth.{AWSCredentials, AWSSessionCredentials}
 import com.sumologic.elasticsearch.restlastic.dsl.Dsl._
 import com.sumologic.elasticsearch.restlastic.dsl.V6
 import org.junit.runner.RunWith
 import org.scalatest.{Matchers, WordSpec}
 import org.scalatestplus.junit.JUnitRunner
-import spray.http.HttpHeaders.{Host, RawHeader}
-import spray.http.Uri.Query
-import spray.http.{HttpEntity, _}
 
 @RunWith(classOf[JUnitRunner])
 class AwsRequestSignerTest extends WordSpec with Matchers {
@@ -47,9 +46,8 @@ class AwsRequestSignerTest extends WordSpec with Matchers {
       method = HttpMethods.GET,
       uri = Uri.from(
         host = "host.foo.com",
-        path = "/",
-        query = Query("foo" -> "Zoo", "foo" -> "aha")
-      ),
+        path = "/"
+      ).withQuery(Uri.Query("foo" -> "Zoo", "foo" -> "aha")),
       headers = List(
         RawHeader("Date", "Mon, 09 Sep 2011 23:36:00 GMT"),
         RawHeader("Host", "host.foo.com")
@@ -118,7 +116,7 @@ class AwsRequestSignerTest extends WordSpec with Matchers {
 
   "sign with host header AND specified host:port url, host header wins" in {
     val signer = new TestSigner("", "", dummyCredentials, region, "es")
-    val req = signer.withAuthHeader(HttpRequest(uri = Uri("http://somehost:9200/some/path"),headers = List(HttpHeaders.Host("0.0.0.0"))))
+    val req = signer.withAuthHeader(HttpRequest(uri = Uri("http://somehost:9200/some/path"),headers = List(Host("0.0.0.0"))))
     req.headers.find(_.is("host")).map(_.value).getOrElse("") should be("0.0.0.0")
   }
 

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -25,17 +25,14 @@ import org.json4s.jackson.JsonMethods._
 
 import scala.concurrent.Await
 import akka.actor.ActorSystem
-import akka.io.IO
-import akka.pattern.ask
+import akka.http.scaladsl.Http
+import akka.http.scaladsl.model.{HttpMethod, HttpMethods, HttpRequest, HttpResponse, Uri}
+import akka.http.scaladsl.unmarshalling.Unmarshal
+import akka.stream.ActorMaterializer
 import akka.util.Timeout
 import com.sumologic.elasticsearch.restlastic.dsl.Dsl
 import org.json4s._
 import org.slf4j.LoggerFactory
-import spray.can.Http
-import spray.http.HttpMethods._
-import spray.http.Uri.{Query => UriQuery}
-import spray.http.HttpResponse
-import spray.http._
 
 import scala.concurrent.duration._
 import scala.concurrent.{ExecutionContext, Future}
@@ -97,6 +94,9 @@ abstract class RestlasticSearchClient(endpointProvider: EndpointProvider, signer
                                      (implicit val system: ActorSystem = ActorSystem(),
                                       val timeout: Timeout = Timeout(30 seconds)) extends ScrollClient {
 
+  private implicit val formats: DefaultFormats.type = org.json4s.DefaultFormats
+  private implicit val mat: ActorMaterializer = ActorMaterializer()
+
   protected val logger = LoggerFactory.getLogger(RestlasticSearchClient.getClass)
 
   import Dsl._
@@ -108,7 +108,7 @@ abstract class RestlasticSearchClient(endpointProvider: EndpointProvider, signer
             tpe: Type,
             query: RootObject,
             rawJsonStr: Boolean = true,
-            uriQuery: UriQuery = UriQuery.Empty,
+            uriQuery: Uri.Query = Uri.Query.Empty,
             profile: Boolean = false): Future[SearchResponse] = {
     queryIndices(Seq(index), tpe, query, rawJsonStr, uriQuery, profile)
   }
@@ -117,7 +117,7 @@ abstract class RestlasticSearchClient(endpointProvider: EndpointProvider, signer
                    tpe: Type,
                    query: RootObject,
                    rawJsonStr: Boolean = true,
-                   uriQuery: UriQuery = UriQuery.Empty,
+                   uriQuery: Uri.Query = Uri.Query.Empty,
                    profile: Boolean = false): Future[SearchResponse] = {
     implicit val ec = searchExecutionCtx
     val endpoint = s"/${indices.map(i => i.name).mkString(",")}/${tpe.name}/_search"
@@ -182,7 +182,7 @@ abstract class RestlasticSearchClient(endpointProvider: EndpointProvider, signer
 
   def deleteById(index: Index, tpe: Type, id: String): Future[DeleteResponse] = {
     implicit val ec = indexExecutionCtx
-    runEsCommand(NoOp, s"/${index.name}/${tpe.name}/$id", DELETE).map(_.mappedTo[DeleteResponse])
+    runEsCommand(NoOp, s"/${index.name}/${tpe.name}/$id", HttpMethods.DELETE).map(_.mappedTo[DeleteResponse])
   }
 
   def deleteByQuery(index: Index,
@@ -203,7 +203,7 @@ abstract class RestlasticSearchClient(endpointProvider: EndpointProvider, signer
 
   def documentExistsById(index: Index, tpe: Type, id: String): Future[Boolean] = {
     implicit val ec = indexExecutionCtx
-    runEsCommand(NoOp, s"/${index.name}/${tpe.name}/$id", HEAD).map(_ => true).recover {
+    runEsCommand(NoOp, s"/${index.name}/${tpe.name}/$id", HttpMethods.HEAD).map(_ => true).recover {
       case ex: ElasticErrorResponse if ex.status == 404 =>
         false
     }
@@ -241,14 +241,14 @@ abstract class RestlasticSearchClient(endpointProvider: EndpointProvider, signer
 
   def getMapping(index: Index, tpe: Type): Future[RawJsonResponse] = {
     implicit val ec = searchExecutionCtx
-    runEsCommand(EmptyObject, s"/${index.name}/_mapping/${tpe.name}", GET)
+    runEsCommand(EmptyObject, s"/${index.name}/_mapping/${tpe.name}", HttpMethods.GET)
   }
 
   def createIndex(index: Index, settings: Option[IndexSetting] = None): Future[RawJsonResponse]
 
   def deleteIndex(index: Index): Future[RawJsonResponse] = {
     implicit val ec = indexExecutionCtx
-    runEsCommand(EmptyObject, s"/${index.name}", DELETE)
+    runEsCommand(EmptyObject, s"/${index.name}", HttpMethods.DELETE)
   }
 
   def getScript(scriptId: String, lang: String = ""): Future[ScriptResponse]
@@ -261,7 +261,7 @@ abstract class RestlasticSearchClient(endpointProvider: EndpointProvider, signer
   def deleteDocument(index: Index, tpe: Type, deleteQuery: QueryRoot, pluginEnabled: Boolean = false): Future[RawJsonResponse] = {
     implicit val ec = indexExecutionCtx
     if (pluginEnabled) {
-      runEsCommand(deleteQuery, s"/${index.name}/${tpe.name}/_query", DELETE)
+      runEsCommand(deleteQuery, s"/${index.name}/${tpe.name}/_query", HttpMethods.DELETE)
     } else {
       val response = Await.result(query(index, tpe, deleteQuery, rawJsonStr = false), 10.seconds).rawSearchResponse
       val totalHits = response.hits.total
@@ -301,7 +301,7 @@ abstract class RestlasticSearchClient(endpointProvider: EndpointProvider, signer
                                    params: Map[String, String]): Future[(ScrollId, SearchResponse)] = {
     implicit val ec = searchExecutionCtx
     val endpoint = s"/${indices.map(i => i.name).mkString(",")}/${tpe.name}/_search"
-    runEsCommand(query, endpoint, query = UriQuery(params)).map { resp =>
+    runEsCommand(query, endpoint, query = Uri.Query(params)).map { resp =>
       val sr = resp.mappedTo[SearchResponseWithScrollId]
       (ScrollId(sr._scroll_id), SearchResponse(RawSearchResponse(sr.hits), resp.jsonStr))
     }
@@ -325,8 +325,8 @@ abstract class RestlasticSearchClient(endpointProvider: EndpointProvider, signer
 
   protected def runEsCommand(op: RootObject,
                              endpoint: String,
-                             method: HttpMethod = POST,
-                             query: UriQuery = UriQuery.Empty,
+                             method: HttpMethod = HttpMethods.POST,
+                             query: Uri.Query = Uri.Query.Empty,
                              profile: Boolean = false)
                             (implicit ec: ExecutionContext): Future[RawJsonResponse] = {
     val jsonStr = if (profile) {
@@ -339,39 +339,42 @@ abstract class RestlasticSearchClient(endpointProvider: EndpointProvider, signer
 
   def runRawEsRequest(op: String,
                       endpoint: String,
-                      method: HttpMethod = POST,
-                      query: UriQuery = UriQuery.Empty)
+                      method: HttpMethod = HttpMethods.POST,
+                      query: Uri.Query = Uri.Query.Empty)
                      (implicit ec: ExecutionContext = ExecutionContext.Implicits.global): Future[RawJsonResponse]
 
   protected def runRawEsRequest(op: String,
                                 endpoint: String,
                                 method: HttpMethod,
-                                query: UriQuery,
+                                query: Uri.Query,
                                 request: HttpRequest)
                                (implicit ec: ExecutionContext): Future[RawJsonResponse] = {
     logger.debug(f"Got Rs request: $request (op was $op)")
 
+    val responseFuture: Future[HttpResponse] = Http().singleRequest(request)
 
-    val responseFuture: Future[HttpResponse] = (IO(Http) ? request)(timeout).mapTo[HttpResponse]
-
-    responseFuture.map { response =>
+    responseFuture.flatMap { response =>
       logger.debug(f"Got Es response: $response")
+      val responseBody = Unmarshal(response.entity).to[String]
+
       if (response.status.isFailure) {
-        logger.warn(s"Failure response: ${response.entity.asString.take(500)}")
+          logger.warn(s"Failure response: ${response.status.defaultMessage()}")
         logger.warn(s"Failing request: ${op.take(5000)}")
-        throw ElasticErrorResponse(JString(response.entity.asString), response.status.intValue)
+        responseBody.flatMap(body =>
+          Future.failed(ElasticErrorResponse(JString(body), response.status.intValue)))
+      } else {
+        responseBody.map(RawJsonResponse)
       }
-      RawJsonResponse(response.entity.asString)
     }
   }
 
-  protected def buildUri(path: String, query: UriQuery = UriQuery.Empty): Uri = {
+  protected def buildUri(path: String, query: Uri.Query = Uri.Query.Empty): Uri = {
     val ep = endpointProvider.endpoint
     val scheme = ep.port match {
       case 443 => "https"
       case _ => "http"
     }
-    Uri.from(scheme = scheme, host = ep.host, port = ep.port, path = path, query = query)
+    Uri.from(scheme = scheme, host = ep.host, port = ep.port, path = path).withQuery(query)
   }
 }
 

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -358,7 +358,7 @@ abstract class RestlasticSearchClient(endpointProvider: EndpointProvider, signer
       val responseBody = Unmarshal(response.entity).to[String]
 
       if (response.status.isFailure) {
-          logger.warn(s"Failure response: ${response.status.defaultMessage()}")
+        logger.warn(s"Failure response: ${response.status.defaultMessage()}")
         logger.warn(s"Failing request: ${op.take(5000)}")
         responseBody.flatMap(body =>
           Future.failed(ElasticErrorResponse(JString(body), response.status.intValue)))

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient6Test.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient6Test.scala
@@ -17,6 +17,7 @@
  * under the License.
  */
 package com.sumologic.elasticsearch.restlastic
+import akka.http.scaladsl.model.HttpMethods
 import akka.util.Timeout
 import com.sumologic.elasticsearch.restlastic.RestlasticSearchClient.ReturnTypes.{Bucket, BucketAggregationResultBody, RawJsonResponse}
 import com.sumologic.elasticsearch.restlastic.dsl.Dsl._
@@ -26,7 +27,6 @@ import org.junit.runner.RunWith
 import org.scalatest._
 import org.scalatest.time.{Millis, Span}
 import org.scalatestplus.junit.JUnitRunner
-import spray.http.HttpMethods.GET
 
 import scala.concurrent.Await
 import scala.concurrent.duration._
@@ -95,7 +95,7 @@ class RestlasticSearchClient6Test extends WordSpec with Matchers with BeforeAndA
       restClient.runRawEsRequest(
         op = "",
         endpoint = s"/${index.name}/_settings/index.store.preload",
-        method = GET).futureValue should be(
+        method = HttpMethods.GET).futureValue should be(
         RawJsonResponse(s"""{"${index.name}":{"settings":{"index":{"store":{"preload":["dvd","nvm"]}}}}}""")
       )
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,11 +10,12 @@ javaSourceVersion = 1.8
 javaTargetVersion = 1.8
 
 # Scala versions
-supportedScalaVersions = 2.11.12
+supportedScalaVersions = 2.11.12, 2.12.8
 defaultScalaVersion = 2.11.12
 
 # Dependencies versions
 akkaVersion = 2.5.23
+akkaHttpVersion = 10.1.10
 awsJavaSdkVersion = 1.11.587
 elasticsearchVersion = 6.1.0
 json4sVersion = 3.6.7
@@ -23,7 +24,6 @@ slf4jVersion = 1.7.26
 luceneVersion = 7.1.0
 mockitoVersion = 2.28.2
 scalatestVersion = 3.0.8
-sprayVersion = 1.3.4
 
 
 # Gradle UI


### PR DESCRIPTION
##### Description
This PR adds **Scala 2.12** support by migrating `Spray` to `Akka HTTP` based on previous works from https://github.com/SumoLogic/elasticsearch-client/pull/158

Most changes here are:
- replacing method `withHeaders` with `addHeaders`
- replacing `UriQuery` with `Uri.Query`
- replacing `GET` with `HttpMethods.GET` and similar

Other changes are either: 
- based on previous attempts (https://github.com/SumoLogic/elasticsearch-client/pull/158)
- using `bulkInsertResult` in one of tests to prevent too many inserts

##### Testing performed
- [x] Run UT on both versions 
  - `./gradlew build`
  - `./gradlew build -PscalaVersion=2.12.8`
- [x] Exported to local `.m2` and run tests on internal project
- [x] Observed Travis job (2.11 is still a default version)