### PR TITLE
Releasing elasticsearch-client 7.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,17 +4,13 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [7.1.0] - 2019-12-03
+
 ### Added
+- Multiple Scala Version support
 - Support for both Scala 2.11 and 2.12
 
 ### Changed
 - Migrated from Spray to Akka HTTP
-
-## [7.0.0-M19] - 2019-11-22
-
-### Added
-- Multiple Scala Version support
-
-### Changed
 - Gradle as a primary build / release tool
 - Artifact id has a Scala version suffix

--- a/README.md
+++ b/README.md
@@ -146,9 +146,9 @@ outside this list)
         signing.gnupg.passphrase=${password_for_imported_sumoapi_key}
         ```
 2. Remove `-SNAPSHOT` suffix from `version` in `build.gradle`
-3. Make a release branch with Scala version and project version, ex. `elasticsearch-client-7.0.0-M19`:
+3. Make a release branch with Scala version and project version, ex. `elasticsearch-client-7.1.1`:
     ```
-    export RELEASE_VERSION=elasticsearch-client-7.0.0-M19
+    export RELEASE_VERSION=elasticsearch-client-7.1.1
     git checkout -b ${RELEASE_VERSION}
     git add build.gradle
     git commit -m "[release] ${RELEASE_VERSION}"
@@ -161,7 +161,7 @@ outside this list)
 5. Go to https://oss.sonatype.org/index.html#stagingRepositories, search for com.sumologic and release your repo. 
 NOTE: If you had to login, reload the URL. It doesn't take you to the right page post-login
 6. Update the `README.md` and `CHANGELOG.md` with the new version and set upcoming snapshot `version` 
-in `build.gradle`, ex. `7.0.0-M20-SNAPSHOT` 
+in `build.gradle`, ex. `7.1.2-SNAPSHOT` 
 7. Commit the change and push as a PR:
     ```
     git add build.gradle README.md CHANGELOG.md

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ subprojects {
     group = "com.sumologic.elasticsearch"
     description = "Elasticsearch Client for Scala that operates against the REST Endpoint"
 
-    version = '7.0.0-M19-SNAPSHOT'
+    version = '7.1.0'
 
     sourceCompatibility = javaSourceVersion
     targetCompatibility = javaTargetVersion

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ subprojects {
     group = "com.sumologic.elasticsearch"
     description = "Elasticsearch Client for Scala that operates against the REST Endpoint"
 
-    version = '7.1.0'
+    version = '7.1.1-SNAPSHOT'
 
     sourceCompatibility = javaSourceVersion
     targetCompatibility = javaTargetVersion


### PR DESCRIPTION
##### Description

Publicly releasing Elasticsearch-client 7.1.0 as:
`elasticsearch-core_2.11:7.1.0`
`elasticsearch-akka_2.11:7.1.0`
`elasticsearch-aws_2.11:7.1.0`
`elasticsearch-core_2.12:7.1.0`
`elasticsearch-akka_2.12:7.1.0`
`elasticsearch-aws_2.12:7.1.0`
