### PR TITLE
ConstantScore query & boost support

### DIFF
--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
@@ -147,13 +147,16 @@ trait QueryDsl extends DslCommons with SortDsl {
     }
   }
 
-  case class Bool(queries: List[BoolQuery], filterContext: FilteredContext = FilteredContext(List())) extends CompoundQuery {
+  case class Bool(queries: List[BoolQuery],
+                  filterContext: FilteredContext = FilteredContext(List()),
+                  boost: Option[Float] = None) extends CompoundQuery {
     val _bool = "bool"
+    val _boost = "boost"
 
     override def toJson(version: EsVersion): Map[String, Any] = Map(_bool -> (queryMap(version) ++ filterContext.toJson(version)))
 
     private def queryMap(version: EsVersion): Map[String, Any] = {
-      queries.map(_.toJson(version)).map(map => (map.keys.head, map(map.keys.head))).toMap
+      queries.map(_.toJson(version)).map(map => (map.keys.head, map(map.keys.head))).toMap ++ boost.map(_boost -> _)
     }
   }
 

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
@@ -217,11 +217,12 @@ trait QueryDsl extends DslCommons with SortDsl {
     override def toJson(version: EsVersion): Map[String, Any] = Map(_lte -> value)
   }
 
-  case class WildcardQuery(key: String, value: String) extends Query {
+  case class WildcardQuery(key: String, value: String, boost: Option[Float] = None) extends Query {
     val _wildcard = "wildcard"
+    val _boost = "boost"
 
     override def toJson(version: EsVersion): Map[String, Any] = {
-      Map(_wildcard -> Map(key -> value))
+      Map(_wildcard -> (Map(key -> value) ++ boost.map(_boost -> _)))
     }
   }
 
@@ -233,11 +234,12 @@ trait QueryDsl extends DslCommons with SortDsl {
     }
   }
 
-  case class TermQuery(key: String, value: String) extends Query {
+  case class TermQuery(key: String, value: String, boost: Option[Float] = None) extends Query {
     val _term = "term"
+    val _boost = "boost"
 
     override def toJson(version: EsVersion): Map[String, Any] = {
-      Map(_term -> Map(key -> value))
+      Map(_term -> (Map(key -> value) ++ boost.map(_boost -> _)))
     }
   }
 
@@ -262,13 +264,14 @@ trait QueryDsl extends DslCommons with SortDsl {
     }
   }
 
-  case class PrefixQuery(key: String, prefix: String)
+  case class PrefixQuery(key: String, prefix: String, boost: Option[Float] = None)
       extends Query {
     val _prefix = "prefix"
+    val _boost = "boost"
 
     override def toJson(version: EsVersion): Map[String, Any] = {
       Map(_prefix ->
-          Map(key -> prefix)
+          (Map(key -> prefix) ++ boost.map(_boost -> _))
       )
     }
   }

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
@@ -69,9 +69,6 @@ trait QueryDsl extends DslCommons with SortDsl {
     }
   }
 
-  case class ConstantScore(filter: Filter) extends SingleField("constant_score", filter) with Filter
-
-
   case class FilteredContext(filter: List[Filter]) extends Query {
     val _filter = "filter"
     val _query = "query"
@@ -479,6 +476,16 @@ trait QueryDsl extends DslCommons with SortDsl {
 
   case class Scroll(id: String, window: String) extends RootObject {
     override def toJson(version: EsVersion): Map[String, Any] = Map("scroll_id" -> id, "scroll" -> window)
+  }
+
+  case class ConstantScore(filter: Query, boost: Float) extends Query {
+    val _constantScore = "constant_score"
+    val _filter = "filter"
+    val _boost = "boost"
+
+    override def toJson(version: EsVersion): Map[String, Any] = {
+      Map(_constantScore -> Map(_filter -> filter.toJson(version), _boost -> boost))
+    }
   }
 
 }

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient6Test.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient6Test.scala
@@ -104,8 +104,7 @@ class RestlasticSearchClient6Test extends WordSpec with Matchers with BeforeAndA
       implicit val formats = org.json4s.DefaultFormats
       val docsCount = 10011
       val documents = (1 to docsCount).map(i => Document(s"doc$i", Map("text7" -> "here7")))
-      val bulkInsertResult = restClient.bulkIndex(index, tpe, documents)
-      Await.result(bulkInsertResult, 20.seconds)
+      restClient.bulkIndex(index, tpe, documents).futureValue
       refresh()
 
       val count = Await.result(restClient.count(index, tpe, new QueryRoot(MatchAll)), 10.seconds)
@@ -119,7 +118,7 @@ class RestlasticSearchClient6Test extends WordSpec with Matchers with BeforeAndA
         refreshAfterDeletion = true,
         useAutoSlices = true)
 
-      val delResult = Await.result(delFut, 20.seconds)
+      val delResult = delFut.futureValue
       parse(delResult.jsonStr).extract[Map[String, String]].keySet should be (Set("task"))
     }
 

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -857,14 +857,17 @@ trait RestlasticSearchClientTest {
       val query = new QueryRoot(
         Bool(
           List(
-            Should(TermQuery("f1", "koala", boost = Some(2.0f))),
-            Should(TermQuery("text", "australia")))))
+            Should(
+              TermQuery("f1", "koala"),
+              TermQuery("text", "australia"),
+              TermQuery("text", "europe", boost = Some(10.0f))))))
       val responseFuture = restClient.query(index, tpe, query)
       whenReady(responseFuture) { response =>
         response.sourceAsMap should be(
           Seq(
-            Map("f1" -> "koala", "text" -> "australia"),
-            Map("f1" -> "wombat", "text" -> "australia")))
+            Map("f1" -> "hedgehog", "text" -> "europe"), // high boost
+            Map("f1" -> "koala", "text" -> "australia"), // two matching terms
+            Map("f1" -> "wombat", "text" -> "australia"))) // just a single matching term
       }
     }
 
@@ -878,12 +881,15 @@ trait RestlasticSearchClientTest {
       val query = new QueryRoot(
         Bool(
           List(
-            Should(WildcardQuery("f1", "*oa*", boost = Some(2.0f))),
-            Should(WildcardQuery("text", "aust*")))))
+            Should(
+              WildcardQuery("f1", "*oa*"),
+              WildcardQuery("text", "aust*"),
+              WildcardQuery("text", "eur*", boost = Some(10.0f))))))
       val responseFuture = restClient.query(index, tpe, query)
       whenReady(responseFuture) { response =>
         response.sourceAsMap should be(
           Seq(
+            Map("f1" -> "hedgehog", "text" -> "europe"),
             Map("f1" -> "koala", "text" -> "australia"),
             Map("f1" -> "wombat", "text" -> "australia")))
       }
@@ -899,12 +905,15 @@ trait RestlasticSearchClientTest {
       val query = new QueryRoot(
         Bool(
           List(
-            Should(PrefixQuery("f1", "koa", boost = Some(2.0f))),
-            Should(PrefixQuery("text", "aus")))))
+            Should(
+              PrefixQuery("f1", "koa"),
+              PrefixQuery("text", "aus"),
+              PrefixQuery("text", "eu", boost = Some(10.0f))))))
       val responseFuture = restClient.query(index, tpe, query)
       whenReady(responseFuture) { response =>
         response.sourceAsMap should be(
           Seq(
+            Map("f1" -> "hedgehog", "text" -> "europe"),
             Map("f1" -> "koala", "text" -> "australia"),
             Map("f1" -> "wombat", "text" -> "australia")))
       }

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClientTest.scala
@@ -43,7 +43,7 @@ trait RestlasticSearchClientTest {
   protected val basicNumericFieldMapping = BasicFieldMapping(IntegerType, None, None, None, None)
 
   override implicit val patienceConfig = PatienceConfig(
-    timeout = scaled(Span(10, Seconds)), interval = scaled(Span(50, Millis)))
+    timeout = scaled(Span(30, Seconds)), interval = scaled(Span(50, Millis)))
 
   def restlasticClient(restClient: => RestlasticSearchClient,
                        indexName: String,
@@ -70,8 +70,7 @@ trait RestlasticSearchClientTest {
     }
 
     def refreshIndex(index: Index): Unit = {
-      implicit val patienceConfig = PatienceConfig(scaled(Span(1500, Millis)), scaled(Span(15, Millis)))
-      restClient.refresh(index).futureValue
+      restClient.refresh(index).flatMap(_ => restClient.flush(index)).futureValue
     }
 
     def indexDocs(docs: Seq[Document], toIndex: Index = index): Unit = {


### PR DESCRIPTION
Boost support added to:
* `TermQuery`,
* `WildcardQuery`,
* `PrefixQuery`.

`ConstantScore` query support.