### PR TITLE
Add option to pass a custom ActorSystem to search client

### DIFF
--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient.scala
@@ -88,11 +88,11 @@ trait RequestSigner {
   def withAuthHeader(httpRequest: HttpRequest): HttpRequest
 }
 
-abstract class RestlasticSearchClient(endpointProvider: EndpointProvider, signer: Option[RequestSigner],
+abstract class RestlasticSearchClient(endpointProvider: EndpointProvider,
                                       override val indexExecutionCtx: ExecutionContext,
                                       searchExecutionCtx: ExecutionContext)
                                      (implicit val system: ActorSystem = ActorSystem(),
-                                      val timeout: Timeout = Timeout(30 seconds)) extends ScrollClient {
+                                      implicit val timeout: Timeout = Timeout(30 seconds)) extends ScrollClient {
 
   private implicit val formats: DefaultFormats.type = org.json4s.DefaultFormats
   private implicit val mat: ActorMaterializer = ActorMaterializer()

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient2.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient2.scala
@@ -20,6 +20,7 @@ package com.sumologic.elasticsearch.restlastic
 
 import java.nio.charset.StandardCharsets
 
+import akka.actor.ActorSystem
 import akka.http.scaladsl.model.{ContentType, ContentTypes, HttpEntity, HttpMethod, HttpMethods, HttpRequest, Uri}
 import akka.util.Timeout
 import com.sumologic.elasticsearch.restlastic.dsl.{Dsl, V2}
@@ -30,8 +31,9 @@ import scala.concurrent.{ExecutionContext, Future}
 class RestlasticSearchClient2(endpointProvider: EndpointProvider, signer: Option[RequestSigner] = None,
                               override val indexExecutionCtx: ExecutionContext = ExecutionContext.Implicits.global,
                               searchExecutionCtx: ExecutionContext = ExecutionContext.Implicits.global)
-                             (override implicit val timeout: Timeout = Timeout(30 seconds))
-  extends RestlasticSearchClient(endpointProvider, signer, indexExecutionCtx, searchExecutionCtx) {
+                             (override implicit val system: ActorSystem = ActorSystem(),
+                              override implicit val timeout: Timeout = Timeout(30 seconds))
+  extends RestlasticSearchClient(endpointProvider, indexExecutionCtx, searchExecutionCtx) {
 
   import Dsl._
   import RestlasticSearchClient.ReturnTypes._

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient6.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient6.scala
@@ -20,6 +20,7 @@ package com.sumologic.elasticsearch.restlastic
 
 import java.nio.charset.StandardCharsets
 
+import akka.actor.ActorSystem
 import akka.http.scaladsl.model.{ContentType, ContentTypes, HttpEntity, HttpMethod, HttpMethods, HttpRequest, Uri}
 import akka.util.Timeout
 import com.sumologic.elasticsearch.restlastic.dsl.{Dsl, V6}
@@ -39,8 +40,9 @@ import scala.concurrent.{ExecutionContext, Future}
 class RestlasticSearchClient6(endpointProvider: EndpointProvider, signer: Option[RequestSigner] = None,
                               override val indexExecutionCtx: ExecutionContext = ExecutionContext.Implicits.global,
                               searchExecutionCtx: ExecutionContext = ExecutionContext.Implicits.global)
-                             (override implicit val timeout: Timeout = Timeout(30 seconds))
-  extends RestlasticSearchClient(endpointProvider, signer, indexExecutionCtx, searchExecutionCtx) {
+                             (override implicit val system: ActorSystem = ActorSystem(),
+                              override implicit val timeout: Timeout = Timeout(30 seconds))
+  extends RestlasticSearchClient(endpointProvider, indexExecutionCtx, searchExecutionCtx) {
 
   private implicit val formats = org.json4s.DefaultFormats
 


### PR DESCRIPTION
Verified locally that we are able to pass a custom `ActorSystem` (`timeout` as well)