### PR TITLE
Allow Queries in place of Filters

### DIFF
--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/AggregationDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/AggregationDsl.scala
@@ -204,7 +204,7 @@ trait AggregationDsl extends DslCommons with QueryDsl {
     }
   }
 
-  case class FiltersAggregation(filters: Map[String, Filter],
+  case class FiltersAggregation(filters: Map[String, Query],
                                 subAggregation: Option[Aggregation] = None,
                                 otherBucket: Boolean = false) extends Aggregation {
     val _aggsName = "filters_agg"

--- a/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
+++ b/elasticsearch-core/src/main/scala/com/sumologic/elasticsearch/restlastic/dsl/QueryDsl.scala
@@ -30,7 +30,7 @@ trait QueryDsl extends DslCommons with SortDsl {
 
   trait CompoundQuery extends Query
 
-  trait Filter extends EsOperation
+  trait Filter extends Query
 
   trait ValueBoost {
     val _boost = "boost"
@@ -72,7 +72,7 @@ trait QueryDsl extends DslCommons with SortDsl {
     }
   }
 
-  case class FilteredContext(filter: List[Filter]) extends Query {
+  case class FilteredContext(filter: List[Query]) extends Query {
     val _filter = "filter"
     val _query = "query"
     val _searchType = "search-type"
@@ -84,7 +84,7 @@ trait QueryDsl extends DslCommons with SortDsl {
     }
   }
 
-  case class MultiTermFilterContext(filter: Filter*) extends Query {
+  case class MultiTermFilterContext(filter: Query*) extends Query {
     val _filter = "filter"
     val _query = "query"
     val _must = "must"
@@ -96,7 +96,7 @@ trait QueryDsl extends DslCommons with SortDsl {
     }
   }
 
-  case class MultiTermFilteredQuery(query: Query, filter: Filter*) extends Query {
+  case class MultiTermFilteredQuery(query: Query, filter: Query*) extends Query {
     val _filtered = "filtered"
     val _filter = "filter"
     val _query = "query"
@@ -155,7 +155,7 @@ trait QueryDsl extends DslCommons with SortDsl {
     }
   }
 
-  case class CompoundFilter(filters: Filter*) extends Filter {
+  case class CompoundFilter(filters: Query*) extends Filter {
     val _bool = "bool"
     val _must = "must"
 

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/ElasticsearchIntegrationTest.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/ElasticsearchIntegrationTest.scala
@@ -23,7 +23,7 @@ import com.sumologic.elasticsearch.restlastic.dsl.Dsl._
 import org.junit.runner.RunWith
 import org.scalatest.concurrent.ScalaFutures
 import org.scalatest.time.{Millis, Span}
-import org.scalatest.{BeforeAndAfterAll, Suite}
+import org.scalatest.{BeforeAndAfterAll, BeforeAndAfterEach, Suite}
 import org.scalatestplus.junit.JUnitRunner
 
 import scala.util.{Random, Try}
@@ -38,7 +38,7 @@ import scala.util.{Random, Try}
   */
 
 @RunWith(classOf[JUnitRunner])
-trait ElasticsearchIntegrationTest extends BeforeAndAfterAll with ScalaFutures {
+trait ElasticsearchIntegrationTest extends BeforeAndAfterEach with ScalaFutures {
   this: Suite =>
   private val indexPrefix = "test-index"
 
@@ -63,14 +63,9 @@ trait ElasticsearchIntegrationTest extends BeforeAndAfterAll with ScalaFutures {
     })
   }
 
-  override def beforeAll(): Unit = {
-    super.beforeAll()
+  override def afterEach(): Unit = {
     Try(delete(Index(s"$indexPrefix*")))
-  }
-
-  override def afterAll(): Unit = {
-    Try(delete(Index(s"$indexPrefix*")))
-    super.afterAll()
+    super.afterEach()
   }
 
   private def delete(index: Index): ReturnTypes.RawJsonResponse = {

--- a/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient6Test.scala
+++ b/elasticsearch-core/src/test/scala/com/sumologic/elasticsearch/restlastic/RestlasticSearchClient6Test.scala
@@ -32,7 +32,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 @RunWith(classOf[JUnitRunner])
-class RestlasticSearchClient6Test extends WordSpec with Matchers with BeforeAndAfterAll
+class RestlasticSearchClient6Test extends WordSpec with Matchers
     with ElasticsearchIntegrationTest with OneInstancePerTest with RestlasticSearchClientTest {
 
   override val restClient = RestlasticSearchClient6Test.restClient


### PR DESCRIPTION
Changing signatures of some case classes to allow Query usage there and making Filter extend Query to retain backwards compatibility.
Also modified test code a bit to do the cleanup after each test instead of before/after all since the last test wouldn't pass locally due to the number of indices already created on the way to it.